### PR TITLE
clean up proxy color definitions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -33,10 +33,7 @@
   --color-pink-mid: #ff4da6;
   --color-pink-light: #ff69b4;
   --color-white: white;
-  --shinyCardEditingPanelBackground: var(--panel-white-90);
-  --shinyCardEditingPanelBackgroundDark: var(--panel-dark-90);
   --viewOnlyButtonTextColor: #aaa;
-  --viewOnlyButtonTextColorDark: var(--color-gray-77);
   --shinyCardOutlineColor: rgba(180, 180, 180, 0.33);
   --shinyCardTextColor: #c1c1c1;
   --crackAnimationColor: #ffd93d;
@@ -46,17 +43,11 @@
   -webkit-user-select: none;
   -webkit-user-callout: none;
   -webkit-highlight: none;
-  --background-color-light: var(--color-white);
-  --text-color-light: var(--color-black);
-  --background-color-dark: var(--color-deep-gray);
-  --text-color-dark: var(--color-gray-e0);
   --link-color-light: #0071f9;
   --link-color-dark: #009aff;
   --card-color: #fafafa;
-  --bottomButtonBackground: var(--color-blue-primary);
   --bottomButtonBackgroundHover: #0069d9;
   --bottomButtonBackgroundActive: #0056b3;
-  --bottomButtonBackgroundDark: var(--color-blue-primary-dark);
   --bottomButtonBackgroundHoverDark: #1a91ff;
   --bottomButtonBackgroundActiveDark: #299fff;
   --dangerButtonBackground: #ff3b30;
@@ -71,130 +62,52 @@
   --resignButtonBackgroundDark: #cc0000;
   --resignButtonBackgroundHoverDark: #b30000;
   --resignButtonBackgroundActiveDark: #990000;
-  --cancelButtonBackground: var(--color-gray-f0);
-  --cancelButtonBackgroundHover: var(--color-gray-e0);
-  --cancelButtonBackgroundActive: var(--color-gray-d0);
-  --cancelButtonBackgroundDark: var(--color-gray-33);
-  --cancelButtonBackgroundHoverDark: var(--color-gray-44);
-  --cancelButtonBackgroundActiveDark: var(--color-gray-55);
-  --buttonBackgroundDisabled: var(--color-gray-a0);
-  --buttonBackgroundDisabledDark: var(--color-gray-55);
   --modalOverlayBackground: rgba(0, 0, 0, 0.3);
   --modalOverlayBackgroundDark: rgba(0, 0, 0, 0.5);
-  --modalBackground: var(--color-white);
-  --modalBackgroundDark: var(--color-deep-gray);
-  --primaryContainerBackground: var(--color-gray-f9);
   --primaryContainerBackgroundDark: #242424;
-  --secondaryContainerBackground: var(--color-gray-f5);
-  --secondaryContainerBackgroundDark: var(--color-gray-27);
-  --menuContainerBackground: var(--color-gray-f9);
-  --menuContainerBackgroundDark: var(--color-gray-25);
-  --menuContainerHoverBackgroundDark: var(--color-gray-27);
-  --closeButtonBackground: var(--color-gray-fb);
-  --closeButtonBackgroundDark: var(--color-gray-23);
   --menuOverlayBackground: rgba(255, 255, 255, 0.93);
-  --menuOverlayBackgroundDark: var(--color-deep-gray);
   --panelBackground: #f8f8f8;
   --panelBackgroundDark: #262626;
   --inventoryModalBackground: #fffffffa;
   --inventoryModalBackgroundDark: #1a1a1afa;
-  --inventoryItemBackground: var(--color-gray-f5);
   --inventoryItemBackgroundDark: #2a2a2a;
-  --primaryTextColor: var(--color-gray-33);
-  --primaryTextColorDark: var(--color-gray-f0);
-  --secondaryTextColor: var(--color-gray-69);
   --secondaryTextColorDark: #b0b0b0;
   --mutedTextColor: #76778788;
   --mutedTextColorHover: #767787af;
   --mutedTextColorDark: #767787a9;
   --mutedTextColorHoverDark: #767787f0;
-  --lightTextColor: var(--color-gray-f5);
-  --blackTextColor: var(--color-black);
-  --tertiaryTextColor: var(--color-gray-55);
-  --tertiaryTextColorDark: var(--color-gray-d0);
-  --darkTertiaryTextColor: var(--color-gray-42);
-  --disabledTextColor: var(--color-gray-99);
   --lightDisabledTextColor2: #aaa;
-  --darkDisabledTextColor: var(--color-gray-77);
   --lightDisabledTextColor: #cecece;
-  --inputBorderColor: var(--color-gray-dd);
   --buildInfoTextColor: #9999a8cc;
   --buildInfoTextColorDark: #9999a8af;
-  --boardStylePickerBackground: var(--panel-light-90);
-  --boardStylePickerBackgroundDark: var(--panel-dark-90);
   --boardCircularButtonBackground: rgba(240, 240, 240, 0.8);
   --boardCircularButtonBackgroundHover: rgba(250, 250, 250, 0.85);
   --boardCircularButtonBackgroundActive: rgba(230, 230, 230, 0.9);
   --boardCircularButtonBackgroundDark: rgba(80, 80, 80, 0.8);
   --boardCircularButtonBackgroundHoverDark: rgba(90, 90, 90, 0.85);
   --boardCircularButtonBackgroundActiveDark: rgba(70, 70, 70, 0.9);
-  --boardCircularButtonText: var(--color-blue-primary);
-  --boardCircularButtonTextDark: var(--color-blue-primary-dark);
   --profileSigninTint: #0e76fd;
   --profileSigninTintDark: #3898ff;
-  --profileConnectedBackground: var(--color-gray-f9de);
-  --profileConnectedBackgroundHover: var(--color-gray-f5);
-  --profileConnectedBackgroundDark: var(--color-gray-25d5);
-  --profileConnectedBackgroundHoverDark: var(--color-gray-27);
   --profileConnectedText: #767787c9;
-  --profilePopoverBackground: var(--color-white);
-  --profilePopoverBackgroundDark: var(--color-deep-gray);
   --navigationTextMuted: #767787;
-  --navigationTextMutedDark: var(--color-gray-a0);
   --iconLinkButtonText: #8f8f9f;
   --iconLinkButtonTextHover: #808090;
   --iconLinkButtonTextDark: #8a8a9a;
   --iconLinkButtonTextHoverDark: #9a9aaa;
-  --navigationBackground: var(--color-gray-f9);
-  --navigationBackgroundHover: var(--color-gray-f5);
-  --navigationBackgroundDark: var(--color-gray-25);
-  --navigationBackgroundHoverDark: var(--color-gray-27);
-  --controlButtonBackground: var(--color-gray-f9de);
-  --controlButtonBackgroundDark: var(--color-gray-25d5);
-  --topControlButtonsBackground: var(--color-gray-f9de);
-  --topControlButtonsBackgroundDark: var(--color-gray-25d5);
-  --notificationBannerBackground: var(--overlay-light-95);
-  --notificationBannerBackgroundDark: var(--overlay-dark-95);
   --notificationBannerShadow: rgba(0, 0, 0, 0.12);
-  --notificationTitleColor: var(--color-blue-0066cc);
-  --notificationTitleColorDark: var(--color-blue-66b3ff);
-  --notificationSubtitleColor: var(--color-gray-69);
-  --notificationSubtitleColorDark: var(--color-gray-99);
-  --notificationCloseButtonBackground: var(--color-gray-fb);
-  --notificationCloseButtonBackgroundDark: var(--color-gray-23);
   --notificationCloseButtonColor: #cecece;
-  --notificationCloseButtonColorDark: var(--color-gray-42);
-  --notificationCloseButtonBackgroundHover: var(--color-gray-f0);
   --notificationCloseButtonBackgroundHoverDark: #2a2a2a;
-  --notificationCloseButtonColorHover: var(--color-gray-99);
-  --notificationCloseButtonColorHoverDark: var(--color-gray-69);
-  --infoPopoverBackground: var(--overlay-light-95);
-  --infoPopoverBackgroundDark: var(--overlay-dark-95);
-  --musicControlButtonColor: var(--color-blue-0066cc);
   --musicControlButtonColorHover: #0052a3;
-  --musicControlButtonColorDark: var(--color-blue-66b3ff);
   --musicControlButtonColorHoverDark: #80c4ff;
   --copyBoardButtonColor: #888888;
-  --copyBoardButtonColorDark: var(--color-gray-99);
   --boardBackgroundLight: #fefcf6;
-  --boardBackgroundDark: var(--color-gray-23);
   --leaderboardRowHoverBackground: rgba(0, 0, 0, 0.04);
   --leaderboardRowHoverBackgroundDark: rgba(255, 255, 255, 0.04);
-  --leaderboardLoadingTextColor: var(--color-gray-77);
   --leaderboardLoadingTextColorDark: #afafaf;
   --leaderboardRatingWinColor: #43a047;
   --leaderboardRatingLossColor: #e53935;
   --leaderboardRatingWinColorDark: #69f0ae;
   --leaderboardRatingLossColorDark: #ff5252;
-  --leaderboardEmojiPlaceholderBackground: var(--color-gray-e0);
-  --leaderboardEmojiPlaceholderBackgroundDark: var(--color-gray-44);
-  --leaderboardTableTextColor: var(--color-gray-33);
-  --leaderboardTableTextColorDark: var(--color-gray-f5);
-  --leaderboardTableBackground: var(--color-white);
-  --leaderboardTableBackgroundDark: var(--color-deep-gray);
-  --leaderboardTableBorderColor: var(--color-gray-dd);
-  --leaderboardTableBorderColorDark: var(--color-gray-33);
-  --leaderboardTableMutedTextColor: var(--color-gray-99);
   --interactiveHoverBackgroundLight: rgba(232, 232, 232, 0.5);
   --interactiveActiveBackgroundLight: rgba(224, 224, 224, 0.6);
   --interactiveHoverBackgroundDark: rgba(70, 70, 70, 0.4);
@@ -208,12 +121,8 @@
   --standardBoxShadow: rgba(0, 0, 0, 0.2);
   --cardBoxShadow: rgba(0, 0, 0, 0.3);
   --lightBoxShadow: rgba(0, 0, 0, 0.15);
-  --pinkButtonBackground: var(--color-pink-light);
-  --pinkButtonBackgroundHover: var(--color-pink-mid);
   --pinkButtonBackgroundActive: #d1477b;
   --pinkButtonBackgroundDisabled: #ffd1dc;
-  --pinkButtonBackgroundDark: var(--color-pink-mid);
-  --pinkButtonBackgroundHoverDark: var(--color-pink-light);
   --pinkButtonBackgroundActiveDark: #ff85c0;
   --pinkButtonBackgroundDisabledDark: #664d57;
   --color-text-on-pink-disabled: rgba(204, 204, 204, 0.77);
@@ -336,8 +245,8 @@ body {
 
 @media (prefers-color-scheme: dark) {
   body {
-    background-color: var(--background-color-dark);
-    color: var(--text-color-dark);
+    background-color: var(--color-deep-gray);
+    color: var(--color-gray-e0);
   }
 
   a {
@@ -347,8 +256,8 @@ body {
 
 @media (prefers-color-scheme: light) {
   body {
-    background-color: var(--background-color-light);
-    color: var(--text-color-light);
+    background-color: var(--color-white);
+    color: var(--color-black);
   }
 
   a {
@@ -394,14 +303,14 @@ img {
   display: flex;
   margin-right: 8px;
   border-radius: 16px;
-  background-color: var(--topControlButtonsBackground);
+  background-color: var(--color-gray-f9de);
 
   @media (max-width: 320px) {
     margin-right: 5px;
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--topControlButtonsBackgroundDark);
+    background-color: var(--color-gray-25d5);
   }
 }
 
@@ -481,7 +390,7 @@ img {
   right: 0;
   top: 100%;
   margin-top: 12px;
-  background-color: var(--shinyCardEditingPanelBackground);
+  background-color: var(--panel-white-90);
   backdrop-filter: blur(5px);
   -webkit-backdrop-filter: blur(5px);
   border-radius: 12px;
@@ -498,7 +407,7 @@ img {
 
 @media (prefers-color-scheme: dark) {
   .shiny-card-editing-panel {
-    background-color: var(--shinyCardEditingPanelBackgroundDark);
+    background-color: var(--panel-dark-90);
     box-shadow: 0 4px 20px var(--cardBoxShadow);
   }
 }
@@ -515,8 +424,8 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--cancelButtonBackground);
-  color: var(--secondaryTextColor);
+  background-color: var(--color-gray-f0);
+  color: var(--color-gray-69);
   border: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -528,11 +437,11 @@ img {
 }
 
 .shiny-card-undo-button:hover:not(:disabled) {
-  background-color: var(--cancelButtonBackgroundHover);
+  background-color: var(--color-gray-e0);
 }
 
 .shiny-card-undo-button:active:not(:disabled) {
-  background-color: var(--cancelButtonBackgroundActive);
+  background-color: var(--color-gray-d0);
 }
 
 .shiny-card-undo-button:disabled {
@@ -541,16 +450,16 @@ img {
 
 @media (prefers-color-scheme: dark) {
   .shiny-card-undo-button {
-    background-color: var(--cancelButtonBackgroundDark);
-    color: var(--disabledTextColor);
+    background-color: var(--color-gray-33);
+    color: var(--color-gray-99);
   }
 
   .shiny-card-undo-button:hover:not(:disabled) {
-    background-color: var(--cancelButtonBackgroundHoverDark);
+    background-color: var(--color-gray-44);
   }
 
   .shiny-card-undo-button:active:not(:disabled) {
-    background-color: var(--cancelButtonBackgroundActiveDark);
+    background-color: var(--color-gray-55);
   }
 }
 
@@ -566,8 +475,8 @@ img {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--cancelButtonBackground);
-  color: var(--bottomButtonBackground);
+  background-color: var(--color-gray-f0);
+  color: var(--color-blue-primary);
   border: none;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -579,24 +488,24 @@ img {
 }
 
 .shiny-card-done-button:hover {
-  background-color: var(--cancelButtonBackgroundHover);
+  background-color: var(--color-gray-e0);
 }
 
 .shiny-card-done-button:active {
-  background-color: var(--cancelButtonBackgroundActive);
+  background-color: var(--color-gray-d0);
 }
 
 @media (prefers-color-scheme: dark) {
   .shiny-card-done-button {
-    background-color: var(--cancelButtonBackgroundDark);
-    color: var(--bottomButtonBackgroundDark);
+    background-color: var(--color-gray-33);
+    color: var(--color-blue-primary-dark);
   }
 
   .shiny-card-done-button:hover {
-    background-color: var(--cancelButtonBackgroundHoverDark);
+    background-color: var(--color-gray-44);
   }
 
   .shiny-card-done-button:active {
-    background-color: var(--cancelButtonBackgroundActiveDark);
+    background-color: var(--color-gray-55);
   }
 }

--- a/src/ui/BoardComponent.tsx
+++ b/src/ui/BoardComponent.tsx
@@ -11,7 +11,7 @@ const CircularButton = styled.button`
   aspect-ratio: 1;
   border-radius: 50%;
   background-color: var(--boardCircularButtonBackground);
-  color: var(--boardCircularButtonText);
+  color: var(--color-blue-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -35,7 +35,7 @@ const CircularButton = styled.button`
 
   @media (prefers-color-scheme: dark) {
     background-color: var(--boardCircularButtonBackgroundDark);
-    color: var(--boardCircularButtonTextDark);
+    color: var(--color-blue-primary-dark);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
@@ -140,7 +140,7 @@ const BoardComponent: React.FC = () => {
           </g>
         ) : (
           <g id="boardBackgroundLayer">
-            <rect x="1" y="101" height="1161" width="1098" fill={prefersDarkMode ? "var(--boardBackgroundDark)" : "var(--boardBackgroundLight)"} />
+            <rect x="1" y="101" height="1161" width="1098" fill={prefersDarkMode ? "var(--color-gray-23)" : "var(--boardBackgroundLight)"} />
             {shouldIncludePangchiuImage && (
               <image
                 href="/assets/bg/Pangchiu.jpg"
@@ -148,7 +148,7 @@ const BoardComponent: React.FC = () => {
                 y="100"
                 width="1100"
                 style={{
-                  backgroundColor: prefersDarkMode ? "var(--boardBackgroundDark)" : "var(--boardBackgroundLight)",
+                  backgroundColor: prefersDarkMode ? "var(--color-gray-23)" : "var(--boardBackgroundLight)",
                   display: isGridVisible ? "none" : "block",
                 }}
               />

--- a/src/ui/BoardStylePicker.tsx
+++ b/src/ui/BoardStylePicker.tsx
@@ -9,7 +9,7 @@ export const BoardStylePicker = styled.div`
   position: fixed;
   bottom: max(50px, calc(env(safe-area-inset-bottom) + 44px));
   left: 8px;
-  background-color: var(--boardStylePickerBackground);
+  background-color: var(--panel-light-90);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
   border-radius: 8px;
@@ -25,7 +25,7 @@ export const BoardStylePicker = styled.div`
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--boardStylePickerBackgroundDark);
+    background-color: var(--panel-dark-90);
   }
 `;
 
@@ -49,7 +49,7 @@ export const ColorSquare = styled.button<{ isSelected?: boolean; colorSet: "ligh
   ${(props) =>
     props.isSelected &&
     `
-    border-color: var(--bottomButtonBackground);
+    border-color: var(--color-blue-primary);
     box-shadow: 0 0 0 3px var(--selectedBorderShadowColor);
   `}
 
@@ -57,7 +57,7 @@ export const ColorSquare = styled.button<{ isSelected?: boolean; colorSet: "ligh
     ${(props) =>
       props.isSelected &&
       `
-      border-color: var(--bottomButtonBackgroundDark);
+      border-color: var(--color-blue-primary-dark);
       box-shadow: 0 0 0 3px var(--selectedBorderShadowColorDark);
     `}
   }

--- a/src/ui/BottomControlsStyles.tsx
+++ b/src/ui/BottomControlsStyles.tsx
@@ -44,7 +44,7 @@ export const BrushButton = styled.button<{ disabled?: boolean; dimmed?: boolean 
   height: 32px;
   border-radius: 16px;
   opacity: ${(props) => (props.dimmed ? 0.77 : 1)};
-  background-color: var(--primaryContainerBackground);
+  background-color: var(--color-gray-f9);
   border: none;
   display: flex;
   justify-content: center;
@@ -181,33 +181,33 @@ export const BottomPillButton = styled.button<{ isPink?: boolean; isBlue?: boole
   align-items: center;
   justify-content: center;
 
-  background-color: ${(props) => (props.isViewOnly ? "var(--cancelButtonBackground)" : props.isBlue ? "var(--cancelButtonBackground)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabled)" : props.isPink ? "var(--pinkButtonBackground)" : "var(--bottomButtonBackground)")};
-  color: ${(props) => (props.isPink && props.disabled ? "var(--color-white)" : props.isViewOnly ? "var(--viewOnlyButtonTextColor)" : props.isBlue ? "var(--bottomButtonBackground)" : "var(--color-white)")};
+  background-color: ${(props) => (props.isViewOnly ? "var(--color-gray-f0)" : props.isBlue ? "var(--color-gray-f0)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabled)" : props.isPink ? "var(--color-pink-light)" : "var(--color-blue-primary)")};
+  color: ${(props) => (props.isPink && props.disabled ? "var(--color-white)" : props.isViewOnly ? "var(--viewOnlyButtonTextColor)" : props.isBlue ? "var(--color-blue-primary)" : "var(--color-white)")};
   border: none;
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: ${(props) => (props.isViewOnly ? "var(--cancelButtonBackground)" : props.isBlue ? "var(--cancelButtonBackgroundHover)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabled)" : props.isPink ? "var(--pinkButtonBackgroundHover)" : "var(--bottomButtonBackgroundHover)")};
+      background-color: ${(props) => (props.isViewOnly ? "var(--color-gray-f0)" : props.isBlue ? "var(--color-gray-e0)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabled)" : props.isPink ? "var(--color-pink-mid)" : "var(--bottomButtonBackgroundHover)")};
     }
   }
 
   &:active {
-    background-color: ${(props) => (props.isViewOnly ? "var(--cancelButtonBackground)" : props.isBlue ? "var(--cancelButtonBackgroundActive)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabled)" : props.isPink ? "var(--pinkButtonBackgroundActive)" : "var(--bottomButtonBackgroundActive)")};
+    background-color: ${(props) => (props.isViewOnly ? "var(--color-gray-f0)" : props.isBlue ? "var(--color-gray-d0)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabled)" : props.isPink ? "var(--pinkButtonBackgroundActive)" : "var(--bottomButtonBackgroundActive)")};
   }
 
   @media (prefers-color-scheme: dark) {
-    color: ${(props) => (props.isPink && props.disabled ? "var(--color-text-on-pink-disabled)" : props.isViewOnly ? "var(--viewOnlyButtonTextColorDark)" : props.isBlue ? "var(--bottomButtonBackgroundDark)" : "var(--color-white)")};
+    color: ${(props) => (props.isPink && props.disabled ? "var(--color-text-on-pink-disabled)" : props.isViewOnly ? "var(--color-gray-77)" : props.isBlue ? "var(--color-blue-primary-dark)" : "var(--color-white)")};
 
-    background-color: ${(props) => (props.isViewOnly ? "var(--cancelButtonBackgroundDark)" : props.isBlue ? "var(--cancelButtonBackgroundDark)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabledDark)" : props.isPink ? "var(--pinkButtonBackgroundDark)" : "var(--bottomButtonBackgroundDark)")};
+    background-color: ${(props) => (props.isViewOnly ? "var(--color-gray-33)" : props.isBlue ? "var(--color-gray-33)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabledDark)" : props.isPink ? "var(--color-pink-mid)" : "var(--color-blue-primary-dark)")};
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: ${(props) => (props.isViewOnly ? "var(--cancelButtonBackgroundDark)" : props.isBlue ? "var(--cancelButtonBackgroundHoverDark)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabledDark)" : props.isPink ? "var(--pinkButtonBackgroundHoverDark)" : "var(--bottomButtonBackgroundHoverDark)")};
+        background-color: ${(props) => (props.isViewOnly ? "var(--color-gray-33)" : props.isBlue ? "var(--color-gray-44)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabledDark)" : props.isPink ? "var(--color-pink-light)" : "var(--bottomButtonBackgroundHoverDark)")};
       }
     }
 
     &:active {
-      background-color: ${(props) => (props.isViewOnly ? "var(--cancelButtonBackgroundDark)" : props.isBlue ? "var(--cancelButtonBackgroundActiveDark)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabledDark)" : props.isPink ? "var(--pinkButtonBackgroundActiveDark)" : "var(--bottomButtonBackgroundActiveDark)")};
+      background-color: ${(props) => (props.isViewOnly ? "var(--color-gray-33)" : props.isBlue ? "var(--color-gray-55)" : props.isPink && props.disabled ? "var(--pinkButtonBackgroundDisabledDark)" : props.isPink ? "var(--pinkButtonBackgroundActiveDark)" : "var(--bottomButtonBackgroundActiveDark)")};
     }
   }
 `;
@@ -216,7 +216,7 @@ export const NavigationListButton = styled.button<{ disabled?: boolean; dimmed?:
   width: 32px;
   height: 32px;
   border-radius: ${(props) => (props.dimmed ? "16px" : "16px")};
-  background-color: var(--cancelButtonBackground);
+  background-color: var(--color-gray-f0);
   border: none;
   display: flex;
   justify-content: center;
@@ -235,7 +235,7 @@ export const NavigationListButton = styled.button<{ disabled?: boolean; dimmed?:
   svg {
     width: ${(props) => (props.dimmed ? "16px" : "13px")};
     height: ${(props) => (props.dimmed ? "16px" : "13px")};
-    color: ${(props) => (props.dimmed ? "var(--primaryTextColor)" : "var(--bottomButtonBackground)")};
+    color: ${(props) => (props.dimmed ? "var(--color-gray-33)" : "var(--color-blue-primary)")};
     overflow: visible;
   }
 
@@ -250,19 +250,19 @@ export const NavigationListButton = styled.button<{ disabled?: boolean; dimmed?:
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: var(--cancelButtonBackgroundHover);
+      background-color: var(--color-gray-e0);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--cancelButtonBackgroundDark);
+    background-color: var(--color-gray-33);
     svg {
-      color: ${(props) => (props.dimmed ? "var(--primaryTextColorDark)" : "var(--bottomButtonBackgroundDark)")};
+      color: ${(props) => (props.dimmed ? "var(--color-gray-f0)" : "var(--color-blue-primary-dark)")};
     }
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: var(--cancelButtonBackgroundHoverDark);
+        background-color: var(--color-gray-44);
       }
     }
   }
@@ -272,7 +272,7 @@ export const ControlButton = styled.button<{ disabled?: boolean }>`
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background-color: var(--cancelButtonBackground);
+  background-color: var(--color-gray-f0);
   border: none;
   display: flex;
   justify-content: center;
@@ -284,36 +284,36 @@ export const ControlButton = styled.button<{ disabled?: boolean }>`
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: ${(props) => (props.disabled ? "var(--cancelButtonBackground)" : "var(--cancelButtonBackgroundHover)")};
+      background-color: ${(props) => (props.disabled ? "var(--color-gray-f0)" : "var(--color-gray-e0)")};
     }
   }
 
   &:active {
-    background-color: ${(props) => (props.disabled ? "var(--cancelButtonBackground)" : "var(--cancelButtonBackgroundActive)")};
+    background-color: ${(props) => (props.disabled ? "var(--color-gray-f0)" : "var(--color-gray-d0)")};
   }
 
   svg {
     width: 16px;
     height: 16px;
-    color: ${(props) => (props.disabled ? "var(--lightDisabledTextColor2)" : "var(--primaryTextColor)")};
+    color: ${(props) => (props.disabled ? "var(--lightDisabledTextColor2)" : "var(--color-gray-33)")};
     overflow: visible;
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--cancelButtonBackgroundDark);
+    background-color: var(--color-gray-33);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: ${(props) => (props.disabled ? "var(--cancelButtonBackgroundDark)" : "var(--cancelButtonBackgroundHoverDark)")};
+        background-color: ${(props) => (props.disabled ? "var(--color-gray-33)" : "var(--color-gray-44)")};
       }
     }
 
     &:active {
-      background-color: ${(props) => (props.disabled ? "var(--cancelButtonBackgroundDark)" : "var(--cancelButtonBackgroundActiveDark)")};
+      background-color: ${(props) => (props.disabled ? "var(--color-gray-33)" : "var(--color-gray-55)")};
     }
 
     svg {
-      color: ${(props) => (props.disabled ? "var(--darkDisabledTextColor)" : "var(--primaryTextColorDark)")};
+      color: ${(props) => (props.disabled ? "var(--color-gray-77)" : "var(--color-gray-f0)")};
     }
   }
 `;
@@ -322,7 +322,7 @@ export const ReactionPicker = styled.div<{ offsetToTheRight?: boolean }>`
   position: absolute;
   bottom: 40px;
   right: ${(props) => (props.offsetToTheRight ? "22px" : "64px")};
-  background-color: var(--boardStylePickerBackground);
+  background-color: var(--panel-light-90);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
   border-radius: 8px;
@@ -336,7 +336,7 @@ export const ReactionPicker = styled.div<{ offsetToTheRight?: boolean }>`
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--boardStylePickerBackgroundDark);
+    background-color: var(--panel-dark-90);
   }
 `;
 
@@ -346,7 +346,7 @@ export const ReactionButton = styled.button`
   padding: 4px 8px;
   cursor: pointer;
   text-align: left;
-  color: var(--primaryTextColor);
+  color: var(--color-gray-33);
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
@@ -359,7 +359,7 @@ export const ReactionButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--primaryTextColorDark);
+    color: var(--color-gray-f0);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {

--- a/src/ui/InfoPopover.tsx
+++ b/src/ui/InfoPopover.tsx
@@ -8,7 +8,7 @@ const StyledInfoPopover = styled.div<{ isOpen: boolean }>`
   top: 56px;
   right: 9pt;
   font-size: 12px;
-  background-color: var(--infoPopoverBackground);
+  background-color: var(--overlay-light-95);
   max-height: calc(100dvh - 113px - env(safe-area-inset-bottom));
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
@@ -31,8 +31,8 @@ const StyledInfoPopover = styled.div<{ isOpen: boolean }>`
   flex-grow: 1;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--infoPopoverBackgroundDark);
-    color: var(--lightTextColor);
+    background-color: var(--overlay-dark-95);
+    color: var(--color-gray-f5);
   }
 
   @media screen and (max-height: 500px) {

--- a/src/ui/InventoryModal.tsx
+++ b/src/ui/InventoryModal.tsx
@@ -39,7 +39,7 @@ const NFTSection = styled.div`
 `;
 
 const Content = styled.div`
-  color: var(--tertiaryTextColor);
+  color: var(--color-gray-55);
   font-size: 0.95rem;
   user-select: none;
   cursor: default;
@@ -53,7 +53,7 @@ const Content = styled.div`
   padding-left: 4px;
 
   @media (prefers-color-scheme: dark) {
-    color: var(--tertiaryTextColorDark);
+    color: var(--color-gray-d0);
   }
 `;
 
@@ -86,7 +86,7 @@ const NFTNameContainer = styled.div`
   width: 100%;
   aspect-ratio: 1/1;
   border-radius: 4px;
-  background: var(--inventoryItemBackground);
+  background: var(--color-gray-f5);
   overflow: hidden;
   cursor: pointer;
   display: flex;

--- a/src/ui/Leaderboard.tsx
+++ b/src/ui/Leaderboard.tsx
@@ -18,7 +18,7 @@ export const LeaderboardContainer = styled.div<{ show: boolean }>`
 const LeaderboardTable = styled.table`
   width: 100%;
   border-collapse: collapse;
-  color: var(--leaderboardTableTextColor);
+  color: var(--color-gray-33);
   table-layout: fixed;
   font-size: 0.85rem;
 
@@ -31,28 +31,28 @@ const LeaderboardTable = styled.table`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--leaderboardTableTextColorDark);
+    color: var(--color-gray-f5);
   }
 
   thead {
     position: sticky;
     top: 0;
-    background-color: var(--leaderboardTableBackground);
+    background-color: var(--color-white);
     z-index: 1;
     font-size: 0.93rem;
 
     @media (prefers-color-scheme: dark) {
-      background-color: var(--leaderboardTableBackgroundDark);
+      background-color: var(--color-deep-gray);
     }
   }
 
   th {
     padding: 0px 0 5px 0px;
-    color: var(--leaderboardTableMutedTextColor);
+    color: var(--color-gray-99);
     font-size: 0.777rem;
 
     @media (prefers-color-scheme: dark) {
-      color: var(--leaderboardTableMutedTextColor);
+      color: var(--color-gray-99);
     }
   }
 
@@ -66,20 +66,20 @@ const LeaderboardTable = styled.table`
 
   th,
   td {
-    border-bottom: 1px solid var(--leaderboardTableBorderColor);
+    border-bottom: 1px solid var(--color-gray-dd);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 
     @media (prefers-color-scheme: dark) {
-      border-bottom: 1px solid var(--leaderboardTableBorderColorDark);
+      border-bottom: 1px solid var(--color-gray-33);
     }
 
     &:nth-child(1) {
       width: 8%;
       text-align: left;
       font-size: 0.75rem;
-      color: var(--leaderboardTableMutedTextColor);
+      color: var(--color-gray-99);
       padding-left: 5px;
 
       @media (max-width: 320px) {
@@ -152,7 +152,7 @@ const TableWrapper = styled.div`
 const LoadingText = styled.div`
   text-align: center;
   font-size: 0.8rem;
-  color: var(--leaderboardLoadingTextColor);
+  color: var(--color-gray-77);
   flex: 1;
   display: flex;
   align-items: center;
@@ -218,7 +218,7 @@ const EmojiPlaceholder = styled.div`
     width: 18px;
     height: 18px;
     border-radius: 50%;
-    background-color: var(--leaderboardEmojiPlaceholderBackground);
+    background-color: var(--color-gray-e0);
 
     @media (max-width: 360px) {
       width: 16px;
@@ -233,7 +233,7 @@ const EmojiPlaceholder = styled.div`
 
   @media (prefers-color-scheme: dark) {
     &:after {
-      background-color: var(--leaderboardEmojiPlaceholderBackgroundDark);
+      background-color: var(--color-gray-44);
     }
   }
 `;

--- a/src/ui/MainMenu.tsx
+++ b/src/ui/MainMenu.tsx
@@ -66,7 +66,7 @@ const CrackContainer = styled.div`
 
 const RockButton = styled.button`
   display: block;
-  background-color: var(--menuContainerBackground);
+  background-color: var(--color-gray-f9);
   border: none;
   border-radius: 20px;
   padding: 3px 6px;
@@ -88,7 +88,7 @@ const RockButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--menuContainerBackgroundDark);
+    background-color: var(--color-gray-25);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
@@ -125,7 +125,7 @@ const RockMenuWrapper = styled.div<{ isOpen: boolean }>`
 
 const RockMenu = styled.div<{ isOpen: boolean; showLeaderboard: boolean }>`
   position: relative;
-  background-color: var(--modalBackground);
+  background-color: var(--color-white);
   border-radius: 10px;
   padding: 6px;
   display: flex;
@@ -140,7 +140,7 @@ const RockMenu = styled.div<{ isOpen: boolean; showLeaderboard: boolean }>`
   z-index: 1;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--modalBackgroundDark);
+    background-color: var(--color-deep-gray);
   }
 `;
 
@@ -149,11 +149,11 @@ const MenuTitleText = styled.i`
   margin-left: -1px;
   font-weight: 995;
   font-size: 25px;
-  color: var(--primaryTextColor);
+  color: var(--color-gray-33);
   cursor: default;
 
   @media (prefers-color-scheme: dark) {
-    color: var(--lightTextColor);
+    color: var(--color-gray-f5);
   }
 `;
 
@@ -175,7 +175,7 @@ const IconLinkButton = styled.a`
   height: 32px;
   padding: 0 9px;
   border-radius: 6px;
-  background-color: var(--menuContainerBackground);
+  background-color: var(--color-gray-f9);
   color: var(--iconLinkButtonText);
   text-decoration: none;
   cursor: pointer;
@@ -190,18 +190,18 @@ const IconLinkButton = styled.a`
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: var(--secondaryContainerBackground);
+      background-color: var(--color-gray-f5);
       color: var(--iconLinkButtonTextHover);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--menuContainerBackgroundDark);
+    background-color: var(--color-gray-25);
     color: var(--iconLinkButtonTextDark);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: var(--menuContainerHoverBackgroundDark);
+        background-color: var(--color-gray-27);
         color: var(--iconLinkButtonTextHoverDark);
       }
     }
@@ -270,7 +270,7 @@ const CloseButton = styled.button`
   display: none;
   align-items: center;
   justify-content: center;
-  background: var(--closeButtonBackground);
+  background: var(--color-gray-fb);
   border: none;
   color: var(--lightDisabledTextColor);
   cursor: pointer;
@@ -296,8 +296,8 @@ const CloseButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--darkTertiaryTextColor);
-    background: var(--closeButtonBackgroundDark);
+    color: var(--color-gray-42);
+    background: var(--color-gray-23);
   }
 `;
 
@@ -313,7 +313,7 @@ const MenuOverlay = styled.div`
   z-index: 2;
 
   @media (prefers-color-scheme: dark) {
-    background: var(--menuOverlayBackgroundDark);
+    background: var(--color-deep-gray);
   }
 
   @media screen and (max-height: 453px) {
@@ -352,25 +352,25 @@ const ExperimentButton = styled.button`
   padding: 10px 20px;
   border: none;
   border-radius: 8px;
-  background: var(--menuContainerBackground);
-  color: var(--primaryTextColor);
+  background: var(--color-gray-f9);
+  color: var(--color-gray-33);
   cursor: pointer;
   font-size: 14px;
   font-weight: 600;
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background: var(--secondaryContainerBackground);
+      background: var(--color-gray-f5);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    background: var(--menuContainerBackgroundDark);
-    color: var(--lightTextColor);
+    background: var(--color-gray-25);
+    color: var(--color-gray-f5);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background: var(--menuContainerHoverBackgroundDark);
+        background: var(--color-gray-27);
       }
     }
   }
@@ -387,7 +387,7 @@ const CopyBoardButton = styled.button`
   padding: 5px;
 
   @media (prefers-color-scheme: dark) {
-    color: var(--copyBoardButtonColorDark);
+    color: var(--color-gray-99);
   }
 `;
 
@@ -396,7 +396,7 @@ const MusicPopover = styled.div<{ isOpen: boolean }>`
   top: 56px;
   right: 9pt;
   font-size: 12px;
-  background-color: var(--infoPopoverBackground);
+  background-color: var(--overlay-light-95);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
   border-radius: 7pt;
@@ -410,8 +410,8 @@ const MusicPopover = styled.div<{ isOpen: boolean }>`
   cursor: default;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--infoPopoverBackgroundDark);
-    color: var(--lightTextColor);
+    background-color: var(--overlay-dark-95);
+    color: var(--color-gray-f5);
   }
 
   @media screen and (max-height: 500px) {
@@ -446,7 +446,7 @@ const MusicControlButton = styled.button`
   border: none;
   border-radius: 6px;
   background: none;
-  color: var(--musicControlButtonColor);
+  color: var(--color-blue-0066cc);
   cursor: pointer;
   font-size: 18px;
   flex: 1;
@@ -463,7 +463,7 @@ const MusicControlButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--musicControlButtonColorDark);
+    color: var(--color-blue-66b3ff);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {

--- a/src/ui/NameEditModal.tsx
+++ b/src/ui/NameEditModal.tsx
@@ -17,23 +17,23 @@ const NameInput = styled.input<{ isValid: boolean }>`
   width: 100%;
   padding: 12px;
   border-radius: 8px;
-  border: 1px solid ${(props) => (props.isValid ? "var(--inputBorderColor)" : "var(--dangerButtonBackground)")};
+  border: 1px solid ${(props) => (props.isValid ? "var(--color-gray-dd)" : "var(--dangerButtonBackground)")};
   font-size: 1rem;
   margin-bottom: 4px;
   box-sizing: border-box;
 
   &:focus {
-    border-color: ${(props) => (props.isValid ? "var(--bottomButtonBackground)" : "var(--dangerButtonBackground)")};
+    border-color: ${(props) => (props.isValid ? "var(--color-blue-primary)" : "var(--dangerButtonBackground)")};
     outline: none;
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--cancelButtonBackgroundDark);
-    color: var(--lightTextColor);
-    border-color: ${(props) => (props.isValid ? "var(--cancelButtonBackgroundHoverDark)" : "var(--dangerButtonBackgroundDark)")};
+    background-color: var(--color-gray-33);
+    color: var(--color-gray-f5);
+    border-color: ${(props) => (props.isValid ? "var(--color-gray-44)" : "var(--dangerButtonBackgroundDark)")};
 
     &:focus {
-      border-color: ${(props) => (props.isValid ? "var(--bottomButtonBackgroundDark)" : "var(--dangerButtonBackgroundDark)")};
+      border-color: ${(props) => (props.isValid ? "var(--color-blue-primary-dark)" : "var(--dangerButtonBackgroundDark)")};
     }
   }
 `;

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -18,7 +18,7 @@ const NavigationPickerContainer = styled.div`
   max-width: 130pt;
   display: flex;
   flex-direction: column;
-  background-color: var(--boardStylePickerBackground);
+  background-color: var(--panel-light-90);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
   border-radius: 7pt;
@@ -27,7 +27,7 @@ const NavigationPickerContainer = styled.div`
   z-index: 5;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--boardStylePickerBackgroundDark);
+    background-color: var(--panel-dark-90);
   }
 
   @media screen and (max-height: 453px) {
@@ -50,7 +50,7 @@ const SectionTitle = styled.div`
   cursor: pointer;
 
   @media (prefers-color-scheme: dark) {
-    color: var(--navigationTextMutedDark);
+    color: var(--color-gray-a0);
   }
 `;
 
@@ -61,7 +61,7 @@ const NavigationPickerButton = styled.button`
   padding: 6px 15px 6px 0;
   cursor: pointer;
   text-align: left;
-  color: var(--primaryTextColor);
+  color: var(--color-gray-33);
   width: 100%;
   display: flex;
   align-items: center;
@@ -78,7 +78,7 @@ const NavigationPickerButton = styled.button`
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--primaryTextColorDark);
+    color: var(--color-gray-f0);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
@@ -101,7 +101,7 @@ const PlaceholderImage = styled.img`
 const HomeBoardButton = styled.button<{ $withTopBorder?: boolean }>`
   position: sticky;
   bottom: 0;
-  background-color: var(--bottomButtonBackground);
+  background-color: var(--color-blue-primary);
   color: white;
   border-radius: 21px;
   padding: 8px 16px;
@@ -130,7 +130,7 @@ const HomeBoardButton = styled.button<{ $withTopBorder?: boolean }>`
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--bottomButtonBackgroundDark);
+    background-color: var(--color-blue-primary-dark);
 
     &:active {
       background-color: var(--bottomButtonBackgroundActiveDark);

--- a/src/ui/NotificationBanner.tsx
+++ b/src/ui/NotificationBanner.tsx
@@ -5,7 +5,7 @@ const NotificationBanner = styled.div<{ isVisible: boolean }>`
   position: fixed;
   top: 56px;
   right: 9pt;
-  background-color: var(--notificationBannerBackground);
+  background-color: var(--overlay-light-95);
   backdrop-filter: blur(3px);
   -webkit-backdrop-filter: blur(3px);
   border-radius: 7pt;
@@ -28,8 +28,8 @@ const NotificationBanner = styled.div<{ isVisible: boolean }>`
   transition: opacity 0.3s ease;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--notificationBannerBackgroundDark);
-    color: var(--lightTextColor);
+    background-color: var(--overlay-dark-95);
+    color: var(--color-gray-f5);
   }
 
   @media screen and (max-height: 500px) {
@@ -71,25 +71,25 @@ const NotificationContent = styled.div`
 const NotificationTitle = styled.div`
   font-size: 18px;
   font-weight: 800;
-  color: var(--notificationTitleColor);
+  color: var(--color-blue-0066cc);
   margin-bottom: 2px;
   line-height: 1.2;
   text-align: left;
 
   @media (prefers-color-scheme: dark) {
-    color: var(--notificationTitleColorDark);
+    color: var(--color-blue-66b3ff);
   }
 `;
 
 const NotificationSubtitle = styled.div`
   font-size: 13px;
   font-weight: 500;
-  color: var(--notificationSubtitleColor);
+  color: var(--color-gray-69);
   line-height: 1.3;
   text-align: left;
 
   @media (prefers-color-scheme: dark) {
-    color: var(--notificationSubtitleColorDark);
+    color: var(--color-gray-99);
   }
 `;
 
@@ -97,7 +97,7 @@ const CloseButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--notificationCloseButtonBackground);
+  background: var(--color-gray-fb);
   border: none;
   color: var(--notificationCloseButtonColor);
   cursor: pointer;
@@ -120,19 +120,19 @@ const CloseButton = styled.button`
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background: var(--notificationCloseButtonBackgroundHover);
-      color: var(--notificationCloseButtonColorHover);
+      background: var(--color-gray-f0);
+      color: var(--color-gray-99);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--notificationCloseButtonColorDark);
-    background: var(--notificationCloseButtonBackgroundDark);
+    color: var(--color-gray-42);
+    background: var(--color-gray-23);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
         background: var(--notificationCloseButtonBackgroundHoverDark);
-        color: var(--notificationCloseButtonColorHoverDark);
+        color: var(--color-gray-69);
       }
     }
   }

--- a/src/ui/ProfileSignIn.tsx
+++ b/src/ui/ProfileSignIn.tsx
@@ -34,7 +34,7 @@ const BaseButton = styled.button`
 `;
 
 const SignInButton = styled(BaseButton)<{ isConnected?: boolean }>`
-  background-color: ${(props) => (props.isConnected ? "var(--profileConnectedBackground)" : "var(--profileSigninTint)")};
+  background-color: ${(props) => (props.isConnected ? "var(--color-gray-f9de)" : "var(--profileSigninTint)")};
 
   padding: 8px 16px;
   font-weight: ${(props) => (props.isConnected ? "750" : "888")};
@@ -46,16 +46,16 @@ const SignInButton = styled(BaseButton)<{ isConnected?: boolean }>`
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: ${(props) => (props.isConnected ? "var(--profileConnectedBackgroundHover)" : "var(--bottomButtonBackgroundHover)")};
+      background-color: ${(props) => (props.isConnected ? "var(--color-gray-f5)" : "var(--bottomButtonBackgroundHover)")};
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: ${(props) => (props.isConnected ? "var(--profileConnectedBackgroundDark)" : "var(--profileSigninTintDark)")};
+    background-color: ${(props) => (props.isConnected ? "var(--color-gray-25d5)" : "var(--profileSigninTintDark)")};
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: ${(props) => (props.isConnected ? "var(--profileConnectedBackgroundHoverDark)" : "var(--bottomButtonBackgroundHoverDark)")};
+        background-color: ${(props) => (props.isConnected ? "var(--color-gray-27)" : "var(--bottomButtonBackgroundHoverDark)")};
       }
     }
   }
@@ -71,7 +71,7 @@ const ConnectButtonPopover = styled.div`
 
 const ConnectButtonWrapper = styled.div`
   padding: 8px;
-  background-color: var(--profilePopoverBackground);
+  background-color: var(--color-white);
   border-radius: 12px;
   box-shadow: 0 6px 20px var(--notificationBannerShadow);
   display: flex;
@@ -79,13 +79,13 @@ const ConnectButtonWrapper = styled.div`
   gap: 8px;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--profilePopoverBackgroundDark);
+    background-color: var(--color-deep-gray);
   }
 `;
 
 const CustomConnectButton = styled(BaseButton)`
   min-width: 130px;
-  color: var(--blackTextColor);
+  color: var(--color-black);
   padding: 12px 24px;
   border: none;
   border-radius: 8px;
@@ -93,21 +93,21 @@ const CustomConnectButton = styled(BaseButton)`
   font-size: 0.81rem;
   cursor: pointer;
 
-  background-color: var(--navigationBackground);
+  background-color: var(--color-gray-f9);
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: var(--navigationBackgroundHover);
+      background-color: var(--color-gray-f5);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--navigationBackgroundDark);
-    color: var(--lightTextColor);
+    background-color: var(--color-gray-25);
+    color: var(--color-gray-f5);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: var(--navigationBackgroundHoverDark);
+        background-color: var(--color-gray-27);
       }
     }
   }

--- a/src/ui/SharedModalComponents.tsx
+++ b/src/ui/SharedModalComponents.tsx
@@ -18,7 +18,7 @@ export const ModalOverlay = styled.div`
 `;
 
 export const ModalPopup = styled.div`
-  background-color: var(--modalBackground);
+  background-color: var(--color-white);
   padding: 24px;
   border-radius: 16px;
   box-shadow: 0 6px 20px var(--standardBoxShadow);
@@ -26,7 +26,7 @@ export const ModalPopup = styled.div`
   max-width: 320px;
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--modalBackgroundDark);
+    background-color: var(--color-deep-gray);
   }
 `;
 
@@ -35,10 +35,10 @@ export const ModalTitle = styled.h3`
   margin-bottom: 16px;
   cursor: default;
   font-size: 1.1rem;
-  color: var(--primaryTextColor);
+  color: var(--color-gray-33);
 
   @media (prefers-color-scheme: dark) {
-    color: var(--primaryTextColorDark);
+    color: var(--color-gray-f0);
   }
 `;
 
@@ -64,92 +64,92 @@ export const Button = styled.button`
 `;
 
 export const CancelButton = styled(Button)`
-  background-color: var(--cancelButtonBackground);
-  color: var(--blackTextColor);
+  background-color: var(--color-gray-f0);
+  color: var(--color-black);
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: var(--cancelButtonBackgroundHover);
+      background-color: var(--color-gray-e0);
     }
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: var(--cancelButtonBackgroundDark);
-    color: var(--lightTextColor);
+    background-color: var(--color-gray-33);
+    color: var(--color-gray-f5);
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: var(--cancelButtonBackgroundHoverDark);
+        background-color: var(--color-gray-44);
       }
     }
   }
 `;
 
 export const SaveButton = styled(Button)<{ disabled: boolean }>`
-  background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabled)" : "var(--bottomButtonBackground)")};
+  background-color: ${(props) => (props.disabled ? "var(--color-gray-a0)" : "var(--color-blue-primary)")};
   color: white;
   min-width: 80px;
   opacity: ${(props) => (props.disabled ? 0.7 : 1)};
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabled)" : "var(--bottomButtonBackgroundHover)")};
+      background-color: ${(props) => (props.disabled ? "var(--color-gray-a0)" : "var(--bottomButtonBackgroundHover)")};
     }
   }
 
   &:active {
-    background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabled)" : "var(--bottomButtonBackgroundActive)")};
+    background-color: ${(props) => (props.disabled ? "var(--color-gray-a0)" : "var(--bottomButtonBackgroundActive)")};
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabledDark)" : "var(--bottomButtonBackgroundDark)")};
+    background-color: ${(props) => (props.disabled ? "var(--color-gray-55)" : "var(--color-blue-primary-dark)")};
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabledDark)" : "var(--bottomButtonBackgroundHoverDark)")};
+        background-color: ${(props) => (props.disabled ? "var(--color-gray-55)" : "var(--bottomButtonBackgroundHoverDark)")};
       }
     }
 
     &:active {
-      background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabledDark)" : "var(--bottomButtonBackgroundActiveDark)")};
+      background-color: ${(props) => (props.disabled ? "var(--color-gray-55)" : "var(--bottomButtonBackgroundActiveDark)")};
     }
   }
 `;
 
 export const DangerButton = styled(Button)<{ disabled?: boolean }>`
-  background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabled)" : "var(--dangerButtonBackground)")};
+  background-color: ${(props) => (props.disabled ? "var(--color-gray-a0)" : "var(--dangerButtonBackground)")};
   color: white;
   min-width: 80px;
   opacity: ${(props) => (props.disabled ? 0.7 : 1)};
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabled)" : "var(--dangerButtonBackgroundHover)")};
+      background-color: ${(props) => (props.disabled ? "var(--color-gray-a0)" : "var(--dangerButtonBackgroundHover)")};
     }
   }
 
   &:active {
-    background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabled)" : "var(--dangerButtonBackgroundActive)")};
+    background-color: ${(props) => (props.disabled ? "var(--color-gray-a0)" : "var(--dangerButtonBackgroundActive)")};
   }
 
   @media (prefers-color-scheme: dark) {
-    background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabledDark)" : "var(--dangerButtonBackgroundDark)")};
+    background-color: ${(props) => (props.disabled ? "var(--color-gray-55)" : "var(--dangerButtonBackgroundDark)")};
 
     @media (hover: hover) and (pointer: fine) {
       &:hover {
-        background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabledDark)" : "var(--dangerButtonBackgroundHoverDark)")};
+        background-color: ${(props) => (props.disabled ? "var(--color-gray-55)" : "var(--dangerButtonBackgroundHoverDark)")};
       }
     }
 
     &:active {
-      background-color: ${(props) => (props.disabled ? "var(--buttonBackgroundDisabledDark)" : "var(--dangerButtonBackgroundActiveDark)")};
+      background-color: ${(props) => (props.disabled ? "var(--color-gray-55)" : "var(--dangerButtonBackgroundActiveDark)")};
     }
   }
 `;
 
 export const Subtitle = styled.p`
   margin: 0 0 24px 0;
-  color: var(--secondaryTextColor);
+  color: var(--color-gray-69);
   font-size: 0.95rem;
   line-height: 1.4;
   cursor: default;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Simplified color variable usage by removing proxy CSS variables and updating all components to use direct color references.

- **Refactors**
  - Replaced indirect color variables (e.g., --cancelButtonBackground) with direct color tokens (e.g., --color-gray-f0) across styles and components.
  - Reduced CSS variable definitions and improved consistency in color usage for both light and dark themes.

<!-- End of auto-generated description by cubic. -->

