### PR TITLE
Fix signOut method localStorage issue

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -196,5 +196,6 @@ export const storage = {
     localStorage.removeItem(STORAGE_KEYS.CARD_STICKERS);
     localStorage.removeItem(STORAGE_KEYS.PROFILE_MONS);
     localStorage.removeItem(STORAGE_KEYS.PLAYER_NONCE);
+    localStorage.removeItem(STORAGE_KEYS.COMPLETED_PROBLEMS);
   },
 };


### PR DESCRIPTION
Clear `COMPLETED_PROBLEMS` from localStorage on sign out to prevent data leakage.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Cleared COMPLETED_PROBLEMS from localStorage when signing out to prevent user data from persisting after logout.

<!-- End of auto-generated description by cubic. -->

