### PR TITLE
tune board picker

### DIFF
--- a/src/ui/BoardStylePicker.tsx
+++ b/src/ui/BoardStylePicker.tsx
@@ -174,6 +174,20 @@ export const PlaceholderImage = styled.img<{ blurred?: boolean }>`
   transform: scale(1.01);
 `;
 
+export const ImagePlaceholderBg = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--color-gray-d0);
+  border-radius: 6px;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--color-gray-a0);
+  }
+`;
+
 export const LockIconOverlay = styled.div`
   position: absolute;
   top: 50%;
@@ -196,6 +210,7 @@ const BoardStylePickerComponent: React.FC = () => {
   const tooltipTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const [imageLoadFailed, setImageLoadFailed] = useState(false);
+  const [imageLoaded, setImageLoaded] = useState(false);
   const isTutorialCompleted = getTutorialCompleted();
 
   const handleColorSetChange = (colorSetKey: ColorSetKey) => (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => {
@@ -230,6 +245,10 @@ const BoardStylePickerComponent: React.FC = () => {
     setImageLoadFailed(true);
   };
 
+  const handleImageLoad = () => {
+    setImageLoaded(true);
+  };
+
   const renderColorSquares = (colorSet: "light" | "dark") => {
     const colors = colorSet === "light" ? colorSets.default : colorSets.darkAndYellow;
     const boardSize = 11;
@@ -260,7 +279,8 @@ const BoardStylePickerComponent: React.FC = () => {
         </ColorSquare>
         {isTutorialCompleted ? (
           <ColorSquare colorSet="light" isSelected={isPangchiuBoardSelected} onClick={!isMobile ? handlePangchiuBoardSelected : undefined} onTouchStart={isMobile ? handlePangchiuBoardSelected : undefined} aria-label="Pangchiu board theme">
-            {!imageLoadFailed && <PlaceholderImage src="/assets/bg/thumb/Pangchiu.jpg" alt="Pangchiu theme preview" loading="lazy" onError={handleImageError} blurred={false} />}
+            {!imageLoaded && <ImagePlaceholderBg />}
+            {!imageLoadFailed && <PlaceholderImage src="/assets/bg/thumb/Pangchiu.jpg" alt="Pangchiu theme preview" loading="lazy" onError={handleImageError} onLoad={handleImageLoad} blurred={false} />}
           </ColorSquare>
         ) : (
           <LockedStyleItem aria-label="Locked board theme" onClick={!isMobile ? handleLockedStyleClick : undefined} onTouchStart={isMobile ? handleLockedStyleClick : undefined}>

--- a/src/ui/BoardStylePicker.tsx
+++ b/src/ui/BoardStylePicker.tsx
@@ -18,9 +18,10 @@ export const BoardStylePicker = styled.div`
   padding: 16px;
   display: flex;
   gap: 18px;
-  touch-action: manipulation;
+  touch-action: none;
   user-select: none;
   -webkit-user-select: none;
+  -webkit-touch-callout: none;
 
   @media screen and (max-height: 453px) {
     bottom: max(44px, calc(env(safe-area-inset-bottom) + 38px));
@@ -74,7 +75,10 @@ export const ColorSquare = styled.button<{ isSelected?: boolean; colorSet: "ligh
   overflow: hidden;
   background: transparent;
   transition: all 0.15s ease;
-  touch-action: manipulation;
+  touch-action: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
 
   ${(props) =>
     props.isSelected &&
@@ -154,7 +158,10 @@ export const LockedStyleItem = styled.div`
   background-color: var(--color-gray-d0);
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
+  touch-action: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
 
   @media (prefers-color-scheme: dark) {
     background-color: var(--color-gray-a0);
@@ -172,6 +179,11 @@ export const PlaceholderImage = styled.img<{ blurred?: boolean }>`
   object-fit: cover;
   filter: ${(props) => (props.blurred ? "blur(1px)" : "none")};
   transform: scale(1.01);
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  touch-action: none;
 `;
 
 export const ImagePlaceholderBg = styled.div`
@@ -182,6 +194,11 @@ export const ImagePlaceholderBg = styled.div`
   height: 100%;
   background-color: var(--color-gray-d0);
   border-radius: 6px;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  pointer-events: none;
+  touch-action: none;
 
   @media (prefers-color-scheme: dark) {
     background-color: var(--color-gray-a0);
@@ -197,6 +214,11 @@ export const LockIconOverlay = styled.div`
   font-size: 15px;
   z-index: 2;
   text-shadow: 0 1px 3px var(--textShadowLight);
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  pointer-events: none;
+  touch-action: none;
 
   @media (prefers-color-scheme: dark) {
     text-shadow: 0 1px 3px var(--textShadowDark);
@@ -214,7 +236,7 @@ const BoardStylePickerComponent: React.FC = () => {
   const isTutorialCompleted = getTutorialCompleted();
 
   const handleColorSetChange = (colorSetKey: ColorSetKey) => (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
+    event.preventDefault();
     setBoardColorSet(colorSetKey);
     toggleExperimentalMode(true, false, false, false);
     setCurrentColorSetKey(colorSetKey);
@@ -222,13 +244,13 @@ const BoardStylePickerComponent: React.FC = () => {
   };
 
   const handlePangchiuBoardSelected = (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
+    event.preventDefault();
     toggleExperimentalMode(false, false, true, false);
     setIsPangchiuBoardSelected(true);
   };
 
   const handleLockedStyleClick = (event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
-    event.stopPropagation();
+    event.preventDefault();
 
     if (tooltipTimerRef.current) {
       clearTimeout(tooltipTimerRef.current);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved the board style picker by fixing touch interactions and adding a placeholder background for the Pangchiu board image.

- **UI Improvements**
  - Disabled unwanted touch actions and text selection for picker elements.
  - Added a gray placeholder background while the Pangchiu image loads.

<!-- End of auto-generated description by cubic. -->

