### PR TITLE
banner tweaks

### DIFF
--- a/src/game/board.ts
+++ b/src/game/board.ts
@@ -1785,7 +1785,7 @@ export function setupBoard() {
       didClickSquare(new Location(y, x));
       event.preventDefault();
       event.stopPropagation();
-    } else if (!target.closest("a, button, select")) {
+    } else if (!target.closest("a, button, select, [data-notification-banner='true']")) {
       hideItemSelectionOrConfirmationOverlay();
       didClickSquare(new Location(-1, -1));
       event.preventDefault();

--- a/src/ui/NotificationBanner.tsx
+++ b/src/ui/NotificationBanner.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { isMobile } from "../utils/misc";
+import { didDismissSomethingWithOutsideTapJustNow } from "./BottomControls";
 
 const NotificationBanner = styled.div<{ isVisible: boolean; dismissType?: "click" | "close" | null }>`
   position: fixed;
@@ -180,17 +181,19 @@ export const NotificationBannerComponent: React.FC<NotificationBannerComponentPr
   const handleNotificationClick = (event: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.stopPropagation();
+    didDismissSomethingWithOutsideTapJustNow();
     onClick();
   };
 
   const handleCloseClick = (event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
+    didDismissSomethingWithOutsideTapJustNow();
     onClose();
   };
 
   return (
-    <NotificationBanner isVisible={isVisible} dismissType={dismissType} onClick={handleNotificationClick}>
+    <NotificationBanner data-notification-banner="true" isVisible={isVisible} dismissType={dismissType} onClick={handleNotificationClick}>
       <NotificationImage src={`https://assets.mons.link/emojipack_hq/${emojiId}.webp`} alt="Notification" />
       <NotificationContent>
         <NotificationTitle>{title}</NotificationTitle>

--- a/src/ui/NotificationBanner.tsx
+++ b/src/ui/NotificationBanner.tsx
@@ -191,7 +191,7 @@ export const NotificationBannerComponent: React.FC<NotificationBannerComponentPr
 
   return (
     <NotificationBanner isVisible={isVisible} dismissType={dismissType} onClick={handleNotificationClick}>
-      <NotificationImage src={`https://assets.mons.link/emojipack/${emojiId}.webp`} alt="Notification" />
+      <NotificationImage src={`https://assets.mons.link/emojipack_hq/${emojiId}.webp`} alt="Notification" />
       <NotificationContent>
         <NotificationTitle>{title}</NotificationTitle>
         <NotificationSubtitle>{subtitle}</NotificationSubtitle>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved the notification banner by using a higher quality image and preventing the board from blinking when interacting with the banner.

- **UI Improvements**
  - Banner now uses a high-resolution emoji image.
  - Board no longer resets or blinks when the banner is clicked or closed.

<!-- End of auto-generated description by cubic. -->

