### PR TITLE
navigate moves history

### DIFF
--- a/cloud/functions/getNfts.js
+++ b/cloud/functions/getNfts.js
@@ -15,24 +15,22 @@ exports.getNfts = onCall(async (request) => {
 
   try {
     const validReactionIds = [9, 17, 20, 26, 30, 31, 40, 50, 54, 61, 63, 74, 101, 109, 132, 146, 148, 163, 168, 173, 180, 189, 209, 210, 217, 224, 225, 228, 232, 236, 243, 245, 246, 250, 256, 257, 258, 267, 271, 281, 283, 289, 302, 303, 313, 316, 318, 325, 328, 338, 347, 356, 374, 382, 389, 393, 396, 401, 403, 405, 407, 429, 430, 444, 465, 466];
-
-    const idCounts = new Map();
-
-    if (sol) {
+    async function fetchCollectionIdCounts(ownerAddress, collectionId) {
+      const idCounts = new Map();
+      if (!ownerAddress) return [];
       let cursor = undefined;
       const limit = 1000;
       let fetched = 0;
       let total = Infinity;
       while (fetched < total) {
         const params = {
-          ownerAddress: sol,
-          grouping: ["collection", "C22esis7kQMbX9JGWsMaKvsh1X5GeBmHPju28jiKDyAP"],
+          ownerAddress,
+          grouping: ["collection", collectionId],
           limit,
         };
         if (cursor) {
           params.cursor = cursor;
         }
-
         const solResponse = await fetch("https://mainnet.helius-rpc.com/?api-key=" + process.env.HELIUS_API_KEY, {
           method: "POST",
           headers: {
@@ -45,17 +43,13 @@ exports.getNfts = onCall(async (request) => {
             params,
           }),
         });
-
         const solData = await solResponse.json();
-
         if (!solResponse.ok) {
-          return { ok: false };
+          return [];
         }
-
         const resultNode = solData?.result || {};
         const items = resultNode?.items || [];
         total = typeof resultNode?.total === "number" ? resultNode.total : total;
-
         for (const item of items) {
           const jsonUri = item?.content?.json_uri || "";
           if (typeof jsonUri !== "string" || jsonUri.length === 0) continue;
@@ -72,19 +66,31 @@ exports.getNfts = onCall(async (request) => {
             idCounts.set(idNum, idCounts.get(idNum) + 1);
           } catch (_) {}
         }
-
         fetched += items.length;
         if (!items.length || fetched >= total || items.length < limit) break;
         cursor = resultNode?.cursor;
         if (!cursor) break;
       }
+      return Array.from(idCounts.entries()).map(([id, count]) => ({ id, count }));
     }
 
-    const swagpack_avatars = Array.from(idCounts.entries()).map(([id, count]) => ({ id, count }));
-    const reactionSet = new Set(validReactionIds);
-    const swagpack_reactions = swagpack_avatars.filter((x) => reactionSet.has(x.id));
+    let swagpack_avatars = [];
+    let swagpack_reactions = [];
+    let specials = [];
 
-    return { ok: true, swagpack_avatars, swagpack_reactions };
+    if (sol) {
+      const primaryCollectionId = "C22esis7kQMbX9JGWsMaKvsh1X5GeBmHPju28jiKDyAP";
+      const specialsCollectionId = "GCcbUaghGawyM76BhJHsHUXb9kq7H3AZhPL7S3p9WajP";
+      const avatarsPromise = fetchCollectionIdCounts(sol, primaryCollectionId);
+      const specialsPromise = fetchCollectionIdCounts(sol, specialsCollectionId);
+      const [avatars, specialIds] = await Promise.all([avatarsPromise, specialsPromise]);
+      swagpack_avatars = avatars;
+      const reactionSet = new Set(validReactionIds);
+      swagpack_reactions = avatars.filter((x) => reactionSet.has(x.id));
+      specials = specialIds;
+    }
+
+    return { ok: true, specials, swagpack_avatars, swagpack_reactions };
   } catch (error) {
     console.error("Error fetching NFTs:", error);
     return { ok: false };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ethers": "^6.15.0",
         "firebase": "^11.10.0",
         "glicko2": "^1.2.1",
-        "mons-web": "^0.1.56",
+        "mons-web": "^0.1.57",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -16380,9 +16380,9 @@
       "license": "MIT"
     },
     "node_modules/mons-web": {
-      "version": "0.1.56",
-      "resolved": "https://registry.npmjs.org/mons-web/-/mons-web-0.1.56.tgz",
-      "integrity": "sha512-88MUqY8IedrMk13xIkdx/bmxV8010bA0yBoJnQSn431r3i+MCV4sYHSp+EOlE/nuUcZzMgF26gzx1qm0AuM/EQ==",
+      "version": "0.1.57",
+      "resolved": "https://registry.npmjs.org/mons-web/-/mons-web-0.1.57.tgz",
+      "integrity": "sha512-YhfVlzTIc2DLXC+2yvPYN/XsXgGGSE1kXOSmBAoXwdCGxTxDiwpRtW0/5mudHTU5gHCJsWLrvCyuniAmsNOEMw==",
       "license": "CC0-1.0"
     },
     "node_modules/ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ethers": "^6.15.0",
         "firebase": "^11.10.0",
         "glicko2": "^1.2.1",
-        "mons-web": "^0.1.57",
+        "mons-web": "^0.1.58",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -16380,9 +16380,9 @@
       "license": "MIT"
     },
     "node_modules/mons-web": {
-      "version": "0.1.57",
-      "resolved": "https://registry.npmjs.org/mons-web/-/mons-web-0.1.57.tgz",
-      "integrity": "sha512-YhfVlzTIc2DLXC+2yvPYN/XsXgGGSE1kXOSmBAoXwdCGxTxDiwpRtW0/5mudHTU5gHCJsWLrvCyuniAmsNOEMw==",
+      "version": "0.1.58",
+      "resolved": "https://registry.npmjs.org/mons-web/-/mons-web-0.1.58.tgz",
+      "integrity": "sha512-LHt0txR6morjwlhH+oJBkKspq7VK1QT9kC4RkMeGzciVbGkt/2cr0mowLU3E45Z7EYh669xCPi2x4KGcYRvJ7g==",
       "license": "CC0-1.0"
     },
     "node_modules/ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ethers": "^6.15.0",
         "firebase": "^11.10.0",
         "glicko2": "^1.2.1",
-        "mons-web": "^0.1.55",
+        "mons-web": "latest",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "ethers": "^6.15.0",
         "firebase": "^11.10.0",
         "glicko2": "^1.2.1",
-        "mons-web": "latest",
+        "mons-web": "^0.1.56",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0",
@@ -16380,9 +16380,9 @@
       "license": "MIT"
     },
     "node_modules/mons-web": {
-      "version": "0.1.55",
-      "resolved": "https://registry.npmjs.org/mons-web/-/mons-web-0.1.55.tgz",
-      "integrity": "sha512-oxKn4mwaZphcwhmbui6+6QLlfJgxkY8gMekn5u0PGp8sdXO63xWqWl/bHIIYtnogVe4CddrBXzKQjVczew26gg==",
+      "version": "0.1.56",
+      "resolved": "https://registry.npmjs.org/mons-web/-/mons-web-0.1.56.tgz",
+      "integrity": "sha512-88MUqY8IedrMk13xIkdx/bmxV8010bA0yBoJnQSn431r3i+MCV4sYHSp+EOlE/nuUcZzMgF26gzx1qm0AuM/EQ==",
       "license": "CC0-1.0"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ethers": "^6.15.0",
     "firebase": "^11.10.0",
     "glicko2": "^1.2.1",
-    "mons-web": "latest",
+    "mons-web": "^0.1.56",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ethers": "^6.15.0",
     "firebase": "^11.10.0",
     "glicko2": "^1.2.1",
-    "mons-web": "^0.1.57",
+    "mons-web": "^0.1.58",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ethers": "^6.15.0",
     "firebase": "^11.10.0",
     "glicko2": "^1.2.1",
-    "mons-web": "^0.1.56",
+    "mons-web": "^0.1.57",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ethers": "^6.15.0",
     "firebase": "^11.10.0",
     "glicko2": "^1.2.1",
-    "mons-web": "^0.1.55",
+    "mons-web": "latest",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -6,6 +6,7 @@ import { colors } from "../content/boardStyles";
 import { playSounds, playReaction } from "../content/sounds";
 import { connection, isCreateNewInviteFlow, isBoardSnapshotFlow, getSnapshotIdAndClearPathIfNeeded, isBotsLoopMode } from "../connection/connection";
 import { showMoveHistoryButton, setWatchOnlyVisible, showResignButton, showVoiceReactionButton, setUndoEnabled, setUndoVisible, disableAndHideUndoResignAndTimerControls, hideTimerButtons, showTimerButtonProgressing, enableTimerVictoryClaim, showPrimaryAction, PrimaryActionType, setInviteLinkActionVisible, setAutomatchVisible, setHomeVisible, setBadgeVisible, setIsReadyToCopyExistingInviteLink, setAutomoveActionVisible, setAutomoveActionEnabled, setAutomatchEnabled, setAutomatchWaitingState, setBotGameOptionVisible, setEndMatchVisible, setEndMatchConfirmed, showWaitingStateText, setBrushAndNavigationButtonDimmed, setNavigationListButtonVisible, setPlaySamePuzzleAgainButtonVisible, closeNavigationAndAppearancePopupIfAny } from "../ui/BottomControls";
+import { triggerMoveHistoryPopupReload } from "../ui/MoveHistoryPopup";
 import { Match } from "../connection/connectionModels";
 import { recalculateRatingsLocallyForUids } from "../utils/playerMetadata";
 import { getNextProblem, Problem, markProblemCompleted, getTutorialCompleted, getTutorialProgress, getInitialProblem } from "../content/problems";
@@ -822,6 +823,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             Board.removeHighlights();
             Board.hideItemSelectionOrConfirmationOverlay();
             updateUndoButtonBasedOnGameState();
+            triggerMoveHistoryPopupReload();
             return;
           case MonsWeb.EventModelKind.GameOver:
             const isVictory = !isOnlineGame || event.color === playerSideColor;
@@ -908,6 +910,8 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
       }
 
       updateUndoButtonBasedOnGameState();
+
+      triggerMoveHistoryPopupReload();
 
       break;
   }

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -64,6 +64,11 @@ export function didSyncTutorialProgress() {
   // TODO: update banner numbers if needed
 }
 
+export function getVerboseTrackingEntities(): string[] {
+  const entities = game.verbose_tracking_entities();
+  return entities.map((e) => String(e.events().length));
+}
+
 function dismissBadgeAndNotificationBannerIfNeeded() {
   setBadgeVisible(false);
   hideNotificationBanner();

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -66,7 +66,7 @@ export function didSyncTutorialProgress() {
 
 export function getVerboseTrackingEntities(): string[] {
   const entities = game.verbose_tracking_entities();
-  return entities.map((e) => String(e.events().length));
+  return entities.map((e) => String(e.events_fen()));
 }
 
 function dismissBadgeAndNotificationBannerIfNeeded() {

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -76,6 +76,20 @@ export function getVerboseTrackingEntities(): string[] {
   });
 }
 
+export function didSelectVerboseTrackingEntity(index: number) {
+  const entities = game.verbose_tracking_entities();
+  if (index < 0 || index >= entities.length) {
+    console.log("didSelectVerboseTrackingEntity", { index, error: "out_of_bounds", count: entities.length });
+    return;
+  }
+  const eventsFen = String(entities[index].events_fen());
+  console.log("didSelectVerboseTrackingEntity", eventsFen);
+}
+
+export function didDismissMoveHistoryPopup() {
+  console.log("didDismissMoveHistoryPopup");
+}
+
 function dismissBadgeAndNotificationBannerIfNeeded() {
   setBadgeVisible(false);
   hideNotificationBanner();

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -1,5 +1,4 @@
 import initMonsWeb, * as MonsWeb from "mons-web";
-import { playerSideMetadata, opponentSideMetadata, showVoiceReactionText, setupPlayerId, hideAllMoveStatuses, hideTimerCountdownDigits, showTimer } from "./board";
 import * as Board from "./board";
 import { Location, Highlight, HighlightKind, AssistedInputKind, Sound, InputModifier, Trace } from "../utils/gameModels";
 import { colors } from "../content/boardStyles";
@@ -298,7 +297,7 @@ export function didClickAutomatchButton() {
   setNavigationListButtonVisible(false);
   Board.hideBoardPlayersInfo();
   Board.removeHighlights();
-  hideAllMoveStatuses();
+  Board.hideAllMoveStatuses();
   isWaitingForInviteToGetAccepted = true;
   Board.runMonsBoardAsDisplayWaitingAnimation();
 
@@ -829,7 +828,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
                 }
               }
             }
-            hideTimerCountdownDigits();
+            Board.hideTimerCountdownDigits();
             break;
           case MonsWeb.EventModelKind.Takeback:
             setNewBoard();
@@ -858,7 +857,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
 
             isGameOver = true;
             disableAndHideUndoResignAndTimerControls();
-            hideTimerCountdownDigits();
+            Board.hideTimerCountdownDigits();
             showRematchInterface();
 
             if (puzzleMode) {
@@ -890,7 +889,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
       }
 
       if (game.winner_color() !== undefined || resignedColor !== undefined) {
-        hideAllMoveStatuses();
+        Board.hideAllMoveStatuses();
       } else {
         updateBoardMoveStatuses();
       }
@@ -954,8 +953,8 @@ export function didClickAutomoveButton() {
 }
 
 function hasBothEthOrSolAddresses(): boolean {
-  const playerSide = playerSideMetadata.ethAddress ?? playerSideMetadata.solAddress;
-  const opponentSide = opponentSideMetadata.ethAddress ?? opponentSideMetadata.solAddress;
+  const playerSide = Board.playerSideMetadata.ethAddress ?? Board.playerSideMetadata.solAddress;
+  const opponentSide = Board.opponentSideMetadata.ethAddress ?? Board.opponentSideMetadata.solAddress;
   return playerSide !== undefined && opponentSide !== undefined && playerSide !== opponentSide;
 }
 
@@ -999,8 +998,8 @@ function updateRatingsLocally(isWin: boolean) {
     return;
   }
 
-  const playerSide = playerSideMetadata.uid;
-  const opponentSide = opponentSideMetadata.uid;
+  const playerSide = Board.playerSideMetadata.uid;
+  const opponentSide = Board.opponentSideMetadata.uid;
 
   const victoryUid = isWin ? playerSide : opponentSide;
   const defeatUid = isWin ? opponentSide : playerSide;
@@ -1086,10 +1085,10 @@ function didConnectTo(match: Match, matchPlayerUid: string, matchId: string) {
 
   if (isWatchOnly) {
     playerSideColor = MonsWeb.Color.White;
-    setupPlayerId(matchPlayerUid, match.color === "black");
+    Board.setupPlayerId(matchPlayerUid, match.color === "black");
   } else {
     playerSideColor = match.color === "white" ? MonsWeb.Color.Black : MonsWeb.Color.White;
-    setupPlayerId(matchPlayerUid, true);
+    Board.setupPlayerId(matchPlayerUid, true);
   }
 
   if (!isWatchOnly) {
@@ -1104,7 +1103,7 @@ function didConnectTo(match: Match, matchPlayerUid: string, matchId: string) {
     game = gameFromFen;
     if (game.winner_color() !== undefined) {
       disableAndHideUndoResignAndTimerControls();
-      hideTimerCountdownDigits();
+      Board.hideTimerCountdownDigits();
     }
   }
 
@@ -1180,7 +1179,7 @@ function showTimerCountdown(onConnect: boolean, timer: any, timerColor: string, 
         if (duration !== undefined && duration !== null) {
           delta = Math.min(Math.floor(duration / 1000), delta);
         }
-        showTimer(timerColor, delta);
+        Board.showTimer(timerColor, delta);
         if (!isWatchOnly && !isPlayerSideTurn()) {
           const target = 90;
           showTimerButtonProgressing(target - delta, target, false);
@@ -1206,7 +1205,7 @@ function updateBoardMoveStatuses() {
 function setNewBoard() {
   Board.updateScore(game.white_score(), game.black_score(), game.winner_color(), resignedColor, winnerByTimerColor);
   if (game.winner_color() !== undefined || resignedColor !== undefined) {
-    hideAllMoveStatuses();
+    Board.hideAllMoveStatuses();
     disableAndHideUndoResignAndTimerControls();
     showRematchInterface();
   } else {
@@ -1241,9 +1240,9 @@ function handleVictoryByTimer(onConnect: boolean, winnerColor: string, justClaim
 
   isGameOver = true;
 
-  hideTimerCountdownDigits();
+  Board.hideTimerCountdownDigits();
   disableAndHideUndoResignAndTimerControls();
-  hideAllMoveStatuses();
+  Board.hideAllMoveStatuses();
 
   Board.removeHighlights();
   Board.hideItemSelectionOrConfirmationOverlay();
@@ -1288,9 +1287,9 @@ function handleResignStatus(onConnect: boolean, resignSenderColor: string) {
     }
   }
 
-  hideTimerCountdownDigits();
+  Board.hideTimerCountdownDigits();
   disableAndHideUndoResignAndTimerControls();
-  hideAllMoveStatuses();
+  Board.hideAllMoveStatuses();
 
   Board.removeHighlights();
   Board.hideItemSelectionOrConfirmationOverlay();
@@ -1313,7 +1312,7 @@ export function didClickInviteActionButtonBeforeThereIsInviteReady() {
   showMoveHistoryButton(false);
   Board.hideBoardPlayersInfo();
   Board.removeHighlights();
-  hideAllMoveStatuses();
+  Board.hideAllMoveStatuses();
   isWaitingForInviteToGetAccepted = true;
   Board.runMonsBoardAsDisplayWaitingAnimation();
 }
@@ -1393,7 +1392,7 @@ export function didReceiveMatchUpdate(match: Match, matchPlayerUid: string, matc
   }
 
   const isOpponentSide = isWatchOnly ? match.color === "black" : true;
-  setupPlayerId(matchPlayerUid, isOpponentSide);
+  Board.setupPlayerId(matchPlayerUid, isOpponentSide);
   Board.updateEmojiAndAuraIfNeeded(match.emojiId.toString(), match.aura, isOpponentSide);
 
   if (match.reaction && match.reaction.uuid && !processedVoiceReactions.has(match.reaction.uuid)) {
@@ -1409,7 +1408,7 @@ export function didReceiveMatchUpdate(match: Match, matchPlayerUid: string, matc
         playSounds([Sound.EmoteReceived]);
         showVideoReaction(showReactionAtOpponentSide, match.reaction.variation);
       } else {
-        showVoiceReactionText(match.reaction.kind, showReactionAtOpponentSide);
+        Board.showVoiceReactionText(match.reaction.kind, showReactionAtOpponentSide);
         playReaction(match.reaction);
       }
       lastReactionTime = currentTime;
@@ -1430,7 +1429,7 @@ export function didReceiveMatchUpdate(match: Match, matchPlayerUid: string, matc
       game = gameFromFen;
       if (game.winner_color() !== undefined) {
         disableAndHideUndoResignAndTimerControls();
-        hideTimerCountdownDigits();
+        Board.hideTimerCountdownDigits();
       }
       setNewBoard();
     }
@@ -1472,7 +1471,7 @@ export function didRecoverMyMatch(match: Match, matchId: string) {
   game = gameFromFen;
   if (game.winner_color() !== undefined) {
     disableAndHideUndoResignAndTimerControls();
-    hideTimerCountdownDigits();
+    Board.hideTimerCountdownDigits();
   }
   verifyMovesIfNeeded(matchId, match.flatMovesString, match.color);
   const movesCount = movesCountOfMatch(match);

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -78,15 +78,18 @@ export function getVerboseTrackingEntities(): string[] {
 export function didSelectVerboseTrackingEntity(index: number) {
   const entities = game.verbose_tracking_entities();
   if (index < 0 || index >= entities.length) {
-    console.log("didSelectVerboseTrackingEntity", { index, error: "out_of_bounds", count: entities.length });
     return;
   }
-  const eventsFen = String(entities[index].events_fen());
-  console.log("didSelectVerboseTrackingEntity", eventsFen);
+  const entity = entities[index];
+  const eventsFen = String(entity.events_fen());
+  console.log(eventsFen);
+
+  const gameFen = entity.fen();
+  // TODO: display selected board state, enter history mode
 }
 
 export function didDismissMoveHistoryPopup() {
-  console.log("didDismissMoveHistoryPopup");
+  // TODO: if in navigation mode, switch to normal mode, display latest board state
 }
 
 function dismissBadgeAndNotificationBannerIfNeeded() {

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -727,16 +727,16 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
               sounds.push(Sound.ScoreMana);
             }
             locationsToUpdate.push(from);
-            Board.indicateWaterSplash(from);
+            Board.indicateWaterSplash(from); // TODO: not in a flashbackMode
             mustReleaseHighlight = true;
-            Board.updateScore(game.white_score(), game.black_score(), game.winner_color(), resignedColor, winnerByTimerColor);
+            Board.updateScore(game.white_score(), game.black_score(), game.winner_color(), resignedColor, winnerByTimerColor); // TODO: not in a flashbackMode
             break;
           case MonsWeb.EventModelKind.MysticAction:
             if (!from || !to) break;
             sounds.push(Sound.MysticAbility);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateElectricHit(to);
+            Board.indicateElectricHit(to); // TODO: not in a flashbackMode
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.DemonAction:
@@ -744,7 +744,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             sounds.push(Sound.DemonAbility);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateFlameGround(to);
+            Board.indicateFlameGround(to); // TODO: not in a flashbackMode
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.DemonAdditionalStep:
@@ -758,7 +758,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             sounds.push(Sound.SpiritAbility);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateSpiritAction(to);
+            Board.indicateSpiritAction(to); // TODO: not in a flashbackMode
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.PickupBomb:
@@ -769,7 +769,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             break;
           case MonsWeb.EventModelKind.UsePotion:
             if (from) {
-              Board.indicatePotionUsage(from);
+              Board.indicatePotionUsage(from); // TODO: not in a flashbackMode
             }
             break;
           case MonsWeb.EventModelKind.PickupPotion:
@@ -802,7 +802,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             sounds.push(Sound.Bomb);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateBombExplosion(to);
+            Board.indicateBombExplosion(to); // TODO: not in a flashbackMode
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.MonAwake:
@@ -813,7 +813,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
           case MonsWeb.EventModelKind.BombExplosion:
             sounds.push(Sound.Bomb);
             if (from) {
-              Board.indicateBombExplosion(from);
+              Board.indicateBombExplosion(from); // TODO: not in a flashbackMode
               locationsToUpdate.push(from);
             }
             break;
@@ -901,13 +901,14 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
         }
       }
 
+       // TODO: not in a flashbackMode
       if (game.winner_color() !== undefined || resignedColor !== undefined) {
         Board.hideAllMoveStatuses();
       } else {
         updateBoardMoveStatuses();
       }
 
-      if (isRemoteInput || isBotInput) {
+      if (!flashbackMode && (isRemoteInput || isBotInput)) {
         for (const trace of traces) {
           Board.drawTrace(trace);
         }
@@ -916,7 +917,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
       playSounds(sounds);
 
       if (popOpponentsEmoji) {
-        Board.popOpponentsEmoji();
+        Board.popOpponentsEmoji(); // TODO: not in a flashbackMode
       }
 
       if (mightKeepHighlightOnLocation !== undefined && !mustReleaseHighlight) {

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -66,6 +66,9 @@ export function didSyncTutorialProgress() {
 
 export function getVerboseTrackingEntities(): string[] {
   const entities = game.verbose_tracking_entities();
+  if (entities.length === 0) {
+    return ["—"];
+  }
   return entities.map((e) => {
     const eventsFen = String(e.events_fen());
     return eventsFen === "" ? "—" : eventsFen;

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -727,16 +727,20 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
               sounds.push(Sound.ScoreMana);
             }
             locationsToUpdate.push(from);
-            Board.indicateWaterSplash(from); // TODO: not in a flashbackMode
+            if (!flashbackMode) {
+              Board.indicateWaterSplash(from);
+              Board.updateScore(game.white_score(), game.black_score(), game.winner_color(), resignedColor, winnerByTimerColor);
+            }
             mustReleaseHighlight = true;
-            Board.updateScore(game.white_score(), game.black_score(), game.winner_color(), resignedColor, winnerByTimerColor); // TODO: not in a flashbackMode
             break;
           case MonsWeb.EventModelKind.MysticAction:
             if (!from || !to) break;
             sounds.push(Sound.MysticAbility);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateElectricHit(to); // TODO: not in a flashbackMode
+            if (!flashbackMode) {
+              Board.indicateElectricHit(to);
+            }
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.DemonAction:
@@ -744,7 +748,9 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             sounds.push(Sound.DemonAbility);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateFlameGround(to); // TODO: not in a flashbackMode
+            if (!flashbackMode) {
+              Board.indicateFlameGround(to);
+            }
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.DemonAdditionalStep:
@@ -758,7 +764,9 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             sounds.push(Sound.SpiritAbility);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateSpiritAction(to); // TODO: not in a flashbackMode
+            if (!flashbackMode) {
+              Board.indicateSpiritAction(to);
+            }
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.PickupBomb:
@@ -768,8 +776,8 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             mustReleaseHighlight = true;
             break;
           case MonsWeb.EventModelKind.UsePotion:
-            if (from) {
-              Board.indicatePotionUsage(from); // TODO: not in a flashbackMode
+            if (from && !flashbackMode) {
+              Board.indicatePotionUsage(from);
             }
             break;
           case MonsWeb.EventModelKind.PickupPotion:
@@ -802,7 +810,9 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             sounds.push(Sound.Bomb);
             locationsToUpdate.push(from);
             locationsToUpdate.push(to);
-            Board.indicateBombExplosion(to); // TODO: not in a flashbackMode
+            if (!flashbackMode) {
+              Board.indicateBombExplosion(to);
+            }
             traces.push(new Trace(from, to));
             break;
           case MonsWeb.EventModelKind.MonAwake:
@@ -812,8 +822,8 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
             break;
           case MonsWeb.EventModelKind.BombExplosion:
             sounds.push(Sound.Bomb);
-            if (from) {
-              Board.indicateBombExplosion(from); // TODO: not in a flashbackMode
+            if (from && !flashbackMode) {
+              Board.indicateBombExplosion(from);
               locationsToUpdate.push(from);
             }
             break;
@@ -901,11 +911,12 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
         }
       }
 
-       // TODO: not in a flashbackMode
-      if (game.winner_color() !== undefined || resignedColor !== undefined) {
-        Board.hideAllMoveStatuses();
-      } else {
-        updateBoardMoveStatuses();
+      if (!flashbackMode) {
+        if (game.winner_color() !== undefined || resignedColor !== undefined) {
+          Board.hideAllMoveStatuses();
+        } else {
+          updateBoardMoveStatuses();
+        }
       }
 
       if (!flashbackMode && (isRemoteInput || isBotInput)) {
@@ -916,8 +927,8 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
 
       playSounds(sounds);
 
-      if (popOpponentsEmoji) {
-        Board.popOpponentsEmoji(); // TODO: not in a flashbackMode
+      if (!flashbackMode && popOpponentsEmoji) {
+        Board.popOpponentsEmoji();
       }
 
       if (mightKeepHighlightOnLocation !== undefined && !mustReleaseHighlight) {

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -89,7 +89,7 @@ export async function go() {
   await initMonsWeb();
 
   playerSideColor = MonsWeb.Color.White;
-  game = MonsWeb.MonsGameModel.new();
+  game = MonsWeb.MonsGameModel.new(); // TODO: enable verbose tracking?
   initialFen = game.fen();
 
   if (experimentalDrawingDevMode) {
@@ -120,7 +120,7 @@ export async function go() {
     const snapshot = decodeURIComponent(getSnapshotIdAndClearPathIfNeeded() || "");
     const gameFromFen = MonsWeb.MonsGameModel.from_fen(snapshot);
     if (!gameFromFen) return;
-    game = gameFromFen;
+    game = gameFromFen; // TODO: enable verbose tracking?
     game.locations_with_content().forEach((loc) => {
       const location = new Location(loc.i, loc.j);
       updateLocation(location);
@@ -169,7 +169,7 @@ export function failedToCreateRematchProposal() {
 
 function rematchInLoopMode() {
   isGameOver = false;
-  game = MonsWeb.MonsGameModel.new();
+  game = MonsWeb.MonsGameModel.new(); // TODO: enable verbose tracking?
   Board.toggleBoardFlipped();
   playerSideColor = playerSideColor === MonsWeb.Color.White ? MonsWeb.Color.Black : MonsWeb.Color.White;
   Board.resetForNewGame();
@@ -196,7 +196,7 @@ export function didJustCreateRematchProposalSuccessfully(inviteId: string) {
   whiteFlatMovesString = null;
   blackFlatMovesString = null;
   playerSideColor = MonsWeb.Color.White;
-  game = MonsWeb.MonsGameModel.new();
+  game = MonsWeb.MonsGameModel.new(); // TODO: enable verbose tracking
 
   resignedColor = undefined;
   winnerByTimerColor = undefined;
@@ -616,13 +616,13 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
       const events = output.events();
 
       if (!isRemoteInput && fenBeforeMove !== "" && turnShouldBeConfirmedForOutputEvents(events, fenBeforeMove)) {
-        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!;
+        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!; // TODO: enable verbose tracking?
         const latestLocation = currentInputs[currentInputs.length - 1];
         Board.showEndTurnConfirmationOverlay(
           game.active_color() === MonsWeb.Color.Black,
           latestLocation,
           () => {
-            game = MonsWeb.MonsGameModel.from_fen(gameFen)!;
+            game = MonsWeb.MonsGameModel.from_fen(gameFen)!; // TODO: enable verbose tracking?
             applyOutput("", output, isRemoteInput, isBotInput, assistedInputKind, inputLocation);
           },
           () => {
@@ -910,7 +910,7 @@ export function playSameCompletedPuzzleAgain() {
 export function resetToTheStartOfThePuzzle() {
   const gameFromFen = MonsWeb.MonsGameModel.from_fen(selectedProblem!.fen);
   if (!gameFromFen) return;
-  game = gameFromFen;
+  game = gameFromFen; // TODO: enable verbose tracking?
   setNewBoard();
   playSounds([Sound.Undo]);
   Board.removeHighlights();
@@ -947,6 +947,7 @@ function verifyMovesIfNeeded(matchId: string, flatMovesString: string, color: st
   }
 
   if (whiteFlatMovesString !== null && blackFlatMovesString !== null) {
+     // TODO: enable verbose tracking?
     let result = game.verify_moves(whiteFlatMovesString, blackFlatMovesString);
     if (result) {
       whiteFlatMovesString = null;
@@ -1070,7 +1071,7 @@ function didConnectTo(match: Match, matchPlayerUid: string, matchId: string) {
   if (!isReconnect || (isReconnect && !game.is_later_than(match.fen)) || isWatchOnly) {
     const gameFromFen = MonsWeb.MonsGameModel.from_fen(match.fen);
     if (!gameFromFen) return;
-    game = gameFromFen;
+    game = gameFromFen; // TODO: enable verbose tracking?
     if (game.winner_color() !== undefined) {
       disableAndHideUndoResignAndTimerControls();
       hideTimerCountdownDigits();
@@ -1309,7 +1310,7 @@ export function didSelectPuzzle(problem: Problem, skipInstructions: boolean = fa
 
   const gameFromFen = MonsWeb.MonsGameModel.from_fen(problem.fen);
   if (!gameFromFen) return;
-  game = gameFromFen;
+  game = gameFromFen; // TODO: enable verbose tracking?
   didStartLocalGame = true;
   setHomeVisible(true);
   setBrushAndNavigationButtonDimmed(true);
@@ -1396,7 +1397,7 @@ export function didReceiveMatchUpdate(match: Match, matchPlayerUid: string, matc
     if (!game.is_later_than(match.fen)) {
       const gameFromFen = MonsWeb.MonsGameModel.from_fen(match.fen);
       if (!gameFromFen) return;
-      game = gameFromFen;
+      game = gameFromFen; // TODO: enable verbose tracking?
       if (game.winner_color() !== undefined) {
         disableAndHideUndoResignAndTimerControls();
         hideTimerCountdownDigits();
@@ -1438,7 +1439,7 @@ export function didRecoverMyMatch(match: Match, matchId: string) {
   playerSideColor = match.color === "white" ? MonsWeb.Color.White : MonsWeb.Color.Black;
   const gameFromFen = MonsWeb.MonsGameModel.from_fen(match.fen);
   if (!gameFromFen) return;
-  game = gameFromFen;
+  game = gameFromFen; // TODO: enable verbose tracking?
   if (game.winner_color() !== undefined) {
     disableAndHideUndoResignAndTimerControls();
     hideTimerCountdownDigits();

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -622,7 +622,7 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
 
       if (!isRemoteInput && fenBeforeMove !== "" && turnShouldBeConfirmedForOutputEvents(events, fenBeforeMove)) {
         const targetGameToConfirm = game;
-        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!; // TODO: use a different designated initializer that would keep moves history
+        game = game.without_last_turn()!;
         const latestLocation = currentInputs[currentInputs.length - 1];
         Board.showEndTurnConfirmationOverlay(
           game.active_color() === MonsWeb.Color.Black,

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -89,7 +89,7 @@ export async function go() {
   await initMonsWeb();
 
   playerSideColor = MonsWeb.Color.White;
-  game = MonsWeb.MonsGameModel.new(); // TODO: enable verbose tracking?
+  game = MonsWeb.MonsGameModel.new();
   initialFen = game.fen();
 
   if (experimentalDrawingDevMode) {
@@ -120,7 +120,7 @@ export async function go() {
     const snapshot = decodeURIComponent(getSnapshotIdAndClearPathIfNeeded() || "");
     const gameFromFen = MonsWeb.MonsGameModel.from_fen(snapshot);
     if (!gameFromFen) return;
-    game = gameFromFen; // TODO: enable verbose tracking?
+    game = gameFromFen;
     game.locations_with_content().forEach((loc) => {
       const location = new Location(loc.i, loc.j);
       updateLocation(location);
@@ -169,7 +169,7 @@ export function failedToCreateRematchProposal() {
 
 function rematchInLoopMode() {
   isGameOver = false;
-  game = MonsWeb.MonsGameModel.new(); // TODO: enable verbose tracking?
+  game = MonsWeb.MonsGameModel.new();
   Board.toggleBoardFlipped();
   playerSideColor = playerSideColor === MonsWeb.Color.White ? MonsWeb.Color.Black : MonsWeb.Color.White;
   Board.resetForNewGame();
@@ -196,7 +196,7 @@ export function didJustCreateRematchProposalSuccessfully(inviteId: string) {
   whiteFlatMovesString = null;
   blackFlatMovesString = null;
   playerSideColor = MonsWeb.Color.White;
-  game = MonsWeb.MonsGameModel.new(); // TODO: enable verbose tracking
+  game = MonsWeb.MonsGameModel.new();
 
   resignedColor = undefined;
   winnerByTimerColor = undefined;
@@ -616,13 +616,13 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
       const events = output.events();
 
       if (!isRemoteInput && fenBeforeMove !== "" && turnShouldBeConfirmedForOutputEvents(events, fenBeforeMove)) {
-        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!; // TODO: enable verbose tracking?
+        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!;
         const latestLocation = currentInputs[currentInputs.length - 1];
         Board.showEndTurnConfirmationOverlay(
           game.active_color() === MonsWeb.Color.Black,
           latestLocation,
           () => {
-            game = MonsWeb.MonsGameModel.from_fen(gameFen)!; // TODO: enable verbose tracking?
+            game = MonsWeb.MonsGameModel.from_fen(gameFen)!;
             applyOutput("", output, isRemoteInput, isBotInput, assistedInputKind, inputLocation);
           },
           () => {
@@ -910,7 +910,7 @@ export function playSameCompletedPuzzleAgain() {
 export function resetToTheStartOfThePuzzle() {
   const gameFromFen = MonsWeb.MonsGameModel.from_fen(selectedProblem!.fen);
   if (!gameFromFen) return;
-  game = gameFromFen; // TODO: enable verbose tracking?
+  game = gameFromFen;
   setNewBoard();
   playSounds([Sound.Undo]);
   Board.removeHighlights();
@@ -947,7 +947,6 @@ function verifyMovesIfNeeded(matchId: string, flatMovesString: string, color: st
   }
 
   if (whiteFlatMovesString !== null && blackFlatMovesString !== null) {
-     // TODO: enable verbose tracking?
     let result = game.verify_moves(whiteFlatMovesString, blackFlatMovesString);
     if (result) {
       whiteFlatMovesString = null;
@@ -1071,7 +1070,7 @@ function didConnectTo(match: Match, matchPlayerUid: string, matchId: string) {
   if (!isReconnect || (isReconnect && !game.is_later_than(match.fen)) || isWatchOnly) {
     const gameFromFen = MonsWeb.MonsGameModel.from_fen(match.fen);
     if (!gameFromFen) return;
-    game = gameFromFen; // TODO: enable verbose tracking?
+    game = gameFromFen;
     if (game.winner_color() !== undefined) {
       disableAndHideUndoResignAndTimerControls();
       hideTimerCountdownDigits();
@@ -1310,7 +1309,7 @@ export function didSelectPuzzle(problem: Problem, skipInstructions: boolean = fa
 
   const gameFromFen = MonsWeb.MonsGameModel.from_fen(problem.fen);
   if (!gameFromFen) return;
-  game = gameFromFen; // TODO: enable verbose tracking?
+  game = gameFromFen;
   didStartLocalGame = true;
   setHomeVisible(true);
   setBrushAndNavigationButtonDimmed(true);
@@ -1397,7 +1396,7 @@ export function didReceiveMatchUpdate(match: Match, matchPlayerUid: string, matc
     if (!game.is_later_than(match.fen)) {
       const gameFromFen = MonsWeb.MonsGameModel.from_fen(match.fen);
       if (!gameFromFen) return;
-      game = gameFromFen; // TODO: enable verbose tracking?
+      game = gameFromFen;
       if (game.winner_color() !== undefined) {
         disableAndHideUndoResignAndTimerControls();
         hideTimerCountdownDigits();
@@ -1439,7 +1438,7 @@ export function didRecoverMyMatch(match: Match, matchId: string) {
   playerSideColor = match.color === "white" ? MonsWeb.Color.White : MonsWeb.Color.Black;
   const gameFromFen = MonsWeb.MonsGameModel.from_fen(match.fen);
   if (!gameFromFen) return;
-  game = gameFromFen; // TODO: enable verbose tracking?
+  game = gameFromFen;
   if (game.winner_color() !== undefined) {
     disableAndHideUndoResignAndTimerControls();
     hideTimerCountdownDigits();

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -960,6 +960,7 @@ function verifyMovesIfNeeded(matchId: string, flatMovesString: string, color: st
     if (result) {
       whiteFlatMovesString = null;
       blackFlatMovesString = null;
+      showMoveHistoryButton(true);
     }
   }
 }
@@ -1105,11 +1106,11 @@ function didConnectTo(match: Match, matchPlayerUid: string, matchId: string) {
     handleResignStatus(true, match.color);
   } else if (!isWatchOnly && !isGameOver && !thereIsWinner) {
     showResignButton();
+    showMoveHistoryButton(true);
     if (isPlayerSideTurn()) {
       hideTimerButtons();
       setUndoVisible(true);
       setAutomoveActionVisible(true);
-      showMoveHistoryButton(true);
     } else {
       showTimerButtonProgressing(0, 90, true);
     }

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -66,7 +66,10 @@ export function didSyncTutorialProgress() {
 
 export function getVerboseTrackingEntities(): string[] {
   const entities = game.verbose_tracking_entities();
-  return entities.map((e) => String(e.events_fen()));
+  return entities.map((e) => {
+    const eventsFen = String(e.events_fen());
+    return eventsFen === "" ? "—" : eventsFen;
+  });
 }
 
 function dismissBadgeAndNotificationBannerIfNeeded() {

--- a/src/game/gameController.ts
+++ b/src/game/gameController.ts
@@ -621,13 +621,14 @@ function applyOutput(fenBeforeMove: string, output: MonsWeb.OutputModel, isRemot
       const events = output.events();
 
       if (!isRemoteInput && fenBeforeMove !== "" && turnShouldBeConfirmedForOutputEvents(events, fenBeforeMove)) {
-        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!;
+        const targetGameToConfirm = game;
+        game = MonsWeb.MonsGameModel.from_fen(fenBeforeMove)!; // TODO: use a different designated initializer that would keep moves history
         const latestLocation = currentInputs[currentInputs.length - 1];
         Board.showEndTurnConfirmationOverlay(
           game.active_color() === MonsWeb.Color.Black,
           latestLocation,
           () => {
-            game = MonsWeb.MonsGameModel.from_fen(gameFen)!;
+            game = targetGameToConfirm;
             applyOutput("", output, isRemoteInput, isBotInput, assistedInputKind, inputLocation);
           },
           () => {

--- a/src/ui/BottomControls.tsx
+++ b/src/ui/BottomControls.tsx
@@ -610,6 +610,7 @@ const BottomControls: React.FC = () => {
           <NavigationPicker showsPuzzles={isNavigationListButtonVisible} showsHomeNavigation={isDeepHomeButtonVisible} navigateHome={handleHomeClick} />
         </div>
       )}
+      {isMoveHistoryPopupVisible && <MoveHistoryPopup ref={moveHistoryPopupRef} />}
       <ControlsContainer>
         {isEndMatchButtonVisible && (
           <BottomPillButton onClick={handleEndMatchClick} isBlue={!isEndMatchConfirmed} disabled={isEndMatchConfirmed} isViewOnly={isEndMatchConfirmed}>
@@ -732,11 +733,6 @@ const BottomControls: React.FC = () => {
               </StickerPill>
             ))}
           </ReactionPillsContainer>
-        )}
-        {isMoveHistoryPopupVisible && (
-          <div ref={moveHistoryPopupRef}>
-            <MoveHistoryPopup />
-          </div>
         )}
         {isResignConfirmVisible && (
           <ResignConfirmation ref={resignConfirmRef}>

--- a/src/ui/BottomControls.tsx
+++ b/src/ui/BottomControls.tsx
@@ -20,8 +20,6 @@ import MoveHistoryPopup from "./MoveHistoryPopup";
 
 const deltaTimeOutsideTap = isMobile ? 42 : 420;
 
-const movesHistoryDisabled = true; // TODO: dev tmp
-
 export enum PrimaryActionType {
   None = "none",
   JoinGame = "joinGame",
@@ -289,9 +287,6 @@ const BottomControls: React.FC = () => {
   };
 
   showMoveHistoryButton = (show: boolean) => {
-    if (movesHistoryDisabled) {
-      return;
-    }
     setIsMoveHistoryButtonVisible(show);
   };
 
@@ -705,6 +700,11 @@ const BottomControls: React.FC = () => {
             <IoSparklesSharp />
           </ControlButton>
         )}
+        {isMoveHistoryButtonVisible && (
+          <ControlButton onClick={!isMobile ? toggleMoveHistoryPopup : undefined} onTouchStart={isMobile ? toggleMoveHistoryPopup : undefined} aria-label="Move History" ref={moveHistoryButtonRef}>
+            <FaScroll />
+          </ControlButton>
+        )}
         {isVoiceReactionButtonVisible && (
           <ControlButton onClick={!isMobile ? toggleReactionPicker : undefined} onTouchStart={isMobile ? toggleReactionPicker : undefined} aria-label="Voice Reaction" ref={voiceReactionButtonRef} disabled={isVoiceReactionDisabled}>
             <FaCommentAlt />
@@ -713,11 +713,6 @@ const BottomControls: React.FC = () => {
         {isResignButtonVisible && (
           <ControlButton onClick={handleResignClick} aria-label="Resign" ref={resignButtonRef} disabled={false}>
             <FaFlag />
-          </ControlButton>
-        )}
-        {isMoveHistoryButtonVisible && (
-          <ControlButton onClick={!isMobile ? toggleMoveHistoryPopup : undefined} onTouchStart={isMobile ? toggleMoveHistoryPopup : undefined} aria-label="Move History" ref={moveHistoryButtonRef}>
-            <FaScroll />
           </ControlButton>
         )}
         <NavigationListButton ref={navigationButtonRef} dimmed={isNavigationButtonDimmed} onClick={!isMobile ? handleNavigationButtonClick : undefined} onTouchStart={isMobile ? handleNavigationButtonClick : undefined} aria-label="Navigation">

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { getVerboseTrackingEntities } from "../game/gameController";
 
 const MoveHistoryPopupContainer = styled.div`
   position: fixed;
@@ -79,50 +80,22 @@ const ItemButton = styled.button`
   }
 `;
 
-const placeholderMoves = [
-  { id: "m1", label: "Move 1: e4" },
-  { id: "m2", label: "Move 2: e5" },
-  { id: "m3", label: "Move 3: Nf3" },
-  { id: "m4", label: "Move 4: Nc6" },
-  { id: "m5", label: "Move 5: Bb5" },
-  { id: "m6", label: "Move 6: a6" },
-  { id: "m7", label: "Move 7: Ba4" },
-  { id: "m8", label: "Move 8: Nf6" },
-  { id: "m9", label: "Move 9: O-O" },
-  { id: "m10", label: "Move 10: Be7" },
-  { id: "m11", label: "Move 11: Re1" },
-  { id: "m12", label: "Move 12: b5" },
-  { id: "m13", label: "Move 13: Bb3" },
-  { id: "m14", label: "Move 14: d6" },
-  { id: "m15", label: "Move 15: c3" },
-  { id: "m16", label: "Move 16: O-O" },
-  { id: "m17", label: "Move 17: h3" },
-  { id: "m18", label: "Move 18: Nb8" },
-  { id: "m19", label: "Move 19: d4" },
-  { id: "m20", label: "Move 20: Nbd7" },
-  { id: "m21", label: "Move 21: c4" },
-  { id: "m22", label: "Move 22: c6" },
-  { id: "m23", label: "Move 23: Nc3" },
-  { id: "m24", label: "Move 24: Qc7" },
-  { id: "m25", label: "Move 25: Be3" },
-  { id: "m26", label: "Move 26: Bb7" },
-  { id: "m27", label: "Move 27: Rc1" },
-  { id: "m28", label: "Move 28: Rfe8" },
-  { id: "m29", label: "Move 29: a3" },
-  { id: "m30", label: "Move 30: Bf8" },
-];
-
 const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
   const preventScroll = (e: React.TouchEvent) => {
     e.preventDefault();
   };
 
+  let items: string[] = [];
+  try {
+    items = getVerboseTrackingEntities();
+  } catch {}
+
   return (
     <MoveHistoryPopupContainer ref={ref} onTouchMove={preventScroll}>
       <ScrollableList>
-        {placeholderMoves.map((item, index) => (
-          <ItemButton key={item.id} onClick={() => {}}>
-            {item.label}
+        {items.map((text, index) => (
+          <ItemButton key={index} onClick={() => {}}>
+            {text}
           </ItemButton>
         ))}
       </ScrollableList>

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import styled from "styled-components";
 import { getVerboseTrackingEntities } from "../game/gameController";
 
+let moveHistoryReloadCallback: (() => void) | null = null;
+export function triggerMoveHistoryPopupReload() {
+  if (moveHistoryReloadCallback) moveHistoryReloadCallback();
+}
+
 const MoveHistoryPopupContainer = styled.div`
   position: fixed;
   bottom: max(50px, calc(env(safe-area-inset-bottom) + 44px));
@@ -89,11 +94,19 @@ const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
     items = getVerboseTrackingEntities();
   } catch {}
 
+  const [version, setVersion] = React.useState(0);
   const listRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const el = listRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
+  }, [version, items.length]);
+
+  React.useEffect(() => {
+    moveHistoryReloadCallback = () => setVersion((v) => v + 1);
+    return () => {
+      moveHistoryReloadCallback = null;
+    };
   }, []);
 
   return (

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "styled-components";
-import { getVerboseTrackingEntities } from "../game/gameController";
+import { getVerboseTrackingEntities, didSelectVerboseTrackingEntity, didDismissMoveHistoryPopup } from "../game/gameController";
 
 let moveHistoryReloadCallback: (() => void) | null = null;
 export function triggerMoveHistoryPopupReload() {
@@ -106,6 +106,9 @@ const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
     moveHistoryReloadCallback = () => setVersion((v) => v + 1);
     return () => {
       moveHistoryReloadCallback = null;
+      try {
+        didDismissMoveHistoryPopup();
+      } catch {}
     };
   }, []);
 
@@ -113,7 +116,7 @@ const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
     <MoveHistoryPopupContainer ref={ref} onTouchMove={preventScroll}>
       <ScrollableList ref={listRef}>
         {items.map((text, index) => (
-          <ItemButton key={index} onClick={() => {}}>
+          <ItemButton key={index} onClick={() => didSelectVerboseTrackingEntity(index)}>
             {text}
           </ItemButton>
         ))}

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -89,9 +89,16 @@ const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
     items = getVerboseTrackingEntities();
   } catch {}
 
+  const listRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, []);
+
   return (
     <MoveHistoryPopupContainer ref={ref} onTouchMove={preventScroll}>
-      <ScrollableList>
+      <ScrollableList ref={listRef}>
         {items.map((text, index) => (
           <ItemButton key={index} onClick={() => {}}>
             {text}

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -6,7 +6,7 @@ const MoveHistoryPopupContainer = styled.div`
   position: fixed;
   bottom: max(50px, calc(env(safe-area-inset-bottom) + 44px));
   right: 8px;
-  min-height: 100px;
+  min-height: 23px;
   max-height: calc(100dvh - 120px - env(safe-area-inset-bottom));
   max-width: 150pt;
   display: flex;

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -79,14 +79,6 @@ const ItemButton = styled.button`
   }
 `;
 
-const PlaceholderImage = styled.img`
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-`;
-
-const placeholderIcon = "data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='2' y='2' width='16' height='16' rx='3' fill='%23cccccc' fill-opacity='0.6'/%3E%3C/svg%3E";
-
 const placeholderMoves = [
   { id: "m1", label: "Move 1: e4" },
   { id: "m2", label: "Move 2: e5" },
@@ -130,7 +122,6 @@ const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
       <ScrollableList>
         {placeholderMoves.map((item, index) => (
           <ItemButton key={item.id} onClick={() => {}}>
-            <PlaceholderImage src={placeholderIcon} alt="" />
             {item.label}
           </ItemButton>
         ))}

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -53,7 +53,6 @@ const ItemButton = styled.button`
   align-items: center;
   gap: 4px;
   line-height: 1.15;
-  text-transform: lowercase;
 
   @media (hover: hover) and (pointer: fine) {
     &:hover {

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -1,8 +1,111 @@
 import React from "react";
-import { ReactionPillsContainer } from "./BottomControlsStyles";
+import styled from "styled-components";
 
-const MoveHistoryPopup: React.FC = () => {
-  return <ReactionPillsContainer>{/* TODO: implement move history navigation UI */}</ReactionPillsContainer>;
-};
+const MoveHistoryPopupContainer = styled.div`
+  position: fixed;
+  bottom: max(50px, calc(env(safe-area-inset-bottom) + 44px));
+  right: 8px;
+  min-height: 100px;
+  max-height: calc(100dvh - 120px - env(safe-area-inset-bottom));
+  max-width: 150pt;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--panel-light-90);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  border-radius: 7pt;
+  padding: 8px;
+  gap: 0;
+  z-index: 7;
+
+  @media (prefers-color-scheme: dark) {
+    background-color: var(--panel-dark-90);
+  }
+
+  @media screen and (max-height: 453px) {
+    bottom: max(44px, calc(env(safe-area-inset-bottom) + 38px));
+  }
+`;
+
+const ScrollableList = styled.div`
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  flex-grow: 1;
+`;
+
+const ItemButton = styled.button`
+  background: none;
+  font-size: 12px;
+  border: none;
+  padding: 4px 10px 4px 0;
+  cursor: pointer;
+  text-align: left;
+  color: var(--color-gray-33);
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  line-height: 1.15;
+  text-transform: lowercase;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: var(--interactiveHoverBackgroundLight);
+    }
+  }
+
+  &:active {
+    background-color: var(--interactiveActiveBackgroundLight);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: var(--color-gray-f0);
+
+    @media (hover: hover) and (pointer: fine) {
+      &:hover {
+        background-color: var(--interactiveHoverBackgroundDark);
+      }
+    }
+
+    &:active {
+      background-color: var(--interactiveActiveBackgroundDark);
+    }
+  }
+`;
+
+const PlaceholderImage = styled.img`
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+`;
+
+const placeholderIcon = "data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='2' y='2' width='16' height='16' rx='3' fill='%23cccccc' fill-opacity='0.6'/%3E%3C/svg%3E";
+
+const placeholderMoves = [
+  { id: "m1", label: "Move 1: e4", completed: true },
+  { id: "m2", label: "Move 2: e5", completed: true },
+  { id: "m3", label: "Move 3: Nf3", completed: true },
+  { id: "m4", label: "Move 4: Nc6", completed: false },
+  { id: "m5", label: "Move 5: Bb5", completed: false },
+];
+
+const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {
+  const preventScroll = (e: React.TouchEvent) => {
+    e.preventDefault();
+  };
+
+  return (
+    <MoveHistoryPopupContainer ref={ref} onTouchMove={preventScroll}>
+      <ScrollableList>
+        {placeholderMoves.map((item, index) => (
+          <ItemButton key={item.id} onClick={() => {}}>
+            <PlaceholderImage src={placeholderIcon} alt="" />
+            {item.label}
+          </ItemButton>
+        ))}
+      </ScrollableList>
+    </MoveHistoryPopupContainer>
+  );
+});
 
 export default MoveHistoryPopup;

--- a/src/ui/MoveHistoryPopup.tsx
+++ b/src/ui/MoveHistoryPopup.tsx
@@ -31,6 +31,12 @@ const ScrollableList = styled.div`
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   flex-grow: 1;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const ItemButton = styled.button`
@@ -82,11 +88,36 @@ const PlaceholderImage = styled.img`
 const placeholderIcon = "data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='2' y='2' width='16' height='16' rx='3' fill='%23cccccc' fill-opacity='0.6'/%3E%3C/svg%3E";
 
 const placeholderMoves = [
-  { id: "m1", label: "Move 1: e4", completed: true },
-  { id: "m2", label: "Move 2: e5", completed: true },
-  { id: "m3", label: "Move 3: Nf3", completed: true },
-  { id: "m4", label: "Move 4: Nc6", completed: false },
-  { id: "m5", label: "Move 5: Bb5", completed: false },
+  { id: "m1", label: "Move 1: e4" },
+  { id: "m2", label: "Move 2: e5" },
+  { id: "m3", label: "Move 3: Nf3" },
+  { id: "m4", label: "Move 4: Nc6" },
+  { id: "m5", label: "Move 5: Bb5" },
+  { id: "m6", label: "Move 6: a6" },
+  { id: "m7", label: "Move 7: Ba4" },
+  { id: "m8", label: "Move 8: Nf6" },
+  { id: "m9", label: "Move 9: O-O" },
+  { id: "m10", label: "Move 10: Be7" },
+  { id: "m11", label: "Move 11: Re1" },
+  { id: "m12", label: "Move 12: b5" },
+  { id: "m13", label: "Move 13: Bb3" },
+  { id: "m14", label: "Move 14: d6" },
+  { id: "m15", label: "Move 15: c3" },
+  { id: "m16", label: "Move 16: O-O" },
+  { id: "m17", label: "Move 17: h3" },
+  { id: "m18", label: "Move 18: Nb8" },
+  { id: "m19", label: "Move 19: d4" },
+  { id: "m20", label: "Move 20: Nbd7" },
+  { id: "m21", label: "Move 21: c4" },
+  { id: "m22", label: "Move 22: c6" },
+  { id: "m23", label: "Move 23: Nc3" },
+  { id: "m24", label: "Move 24: Qc7" },
+  { id: "m25", label: "Move 25: Be3" },
+  { id: "m26", label: "Move 26: Bb7" },
+  { id: "m27", label: "Move 27: Rc1" },
+  { id: "m28", label: "Move 28: Rfe8" },
+  { id: "m29", label: "Move 29: a3" },
+  { id: "m30", label: "Move 30: Bf8" },
 ];
 
 const MoveHistoryPopup = React.forwardRef<HTMLDivElement>((_, ref) => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds an interactive Move History popup that lets players browse and preview past board states without disrupting the live game. Also returns “specials” NFTs from a second collection and updates to mons-web 0.1.58.

- **New Features**
  - Move History popup: live-updating list, tap to enter flashback mode, dismiss to return to live state.
  - Flashback mode: loads the selected state from FEN, suppresses animations/sounds/status updates, and safely restores the board after closing.
  - Move history button is shown at the right times (on connect, after move verification, on player turn).
  - NFT API: fetches and returns specials from an additional collection alongside avatars and reactions.

- **Bug Fixes**
  - End-of-turn confirmation no longer drops history; confirmation restores the correct game state.
  - Move history list refreshes on new moves and takebacks.
  - Safer board updates: explicit Board.* calls and guards to avoid flashback/live state conflicts.

<!-- End of auto-generated description by cubic. -->

