### PR TITLE
Add decorative fight cloud background to event avatars

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -148,6 +148,8 @@
   --wagerButtonBackgroundReadyDark: #218f5e;
   --wagerButtonBackgroundReadyHoverDark: #25a06a;
   --wagerButtonBackgroundReadyActiveDark: #29b176;
+  --fightCloudFill: rgba(180, 190, 210, 0.32);
+  --fightCloudSparkle: rgba(150, 160, 185, 0.5);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -156,6 +158,8 @@
     --instruction-text-color: #fff;
     --instruction-bubble-bg: rgba(30, 32, 42, 0.9);
     --instruction-bubble-stroke: rgba(255, 255, 255, 0.08);
+    --fightCloudFill: rgba(130, 145, 180, 0.28);
+    --fightCloudSparkle: rgba(170, 185, 220, 0.4);
   }
 }
 

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -149,11 +149,30 @@ const GameText = styled.span`
   text-overflow: ellipsis;
 `;
 
+const FightCloudWrapper = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: -2px;
+`;
+
+const FightCloudSvg = styled.svg`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+`;
+
 const EventAvatarStack = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
   gap: 1px;
   flex-shrink: 0;
+  padding: 0 5px;
+  z-index: 1;
 `;
 
 const EventAvatarImage = styled(GameEmojiImage)``;
@@ -168,17 +187,13 @@ const EventOverflowBadge = styled.span`
   padding: 0 3px;
   border-radius: 9px;
   margin-left: 0;
-  background: rgba(128, 128, 128, 0.09);
+  background: none;
   font-size: 0.55rem;
   font-weight: 600;
   color: var(--navigationTextMuted);
   flex-shrink: 0;
   letter-spacing: -0.02em;
   white-space: nowrap;
-
-  @media (prefers-color-scheme: dark) {
-    background: rgba(255, 255, 255, 0.07);
-  }
 `;
 
 const QueuePrimaryContent = styled.span`
@@ -551,17 +566,38 @@ const NavigationPicker: React.FC<NavigationPickerProps> = ({
     const maxVisible = showBadge ? 5 : 6;
     const preview = validParticipants.slice(0, maxVisible);
     const overflow = event.participantCount - preview.length;
+    const itemCount = preview.length + (showBadge && overflow > 0 ? 1 : 0);
+    const cloudW = Math.max(36, itemCount * 21 + 14);
+    const cloudH = 30;
     return (
-      <EventAvatarStack>
-        {preview.map((participant, index) => (
-          <EventAvatarImage
-            key={`${participant.profileId ?? participant.displayName ?? "participant"}_${index}`}
-            src={emojis.getEmojiUrl(participant.emojiId!.toString())}
-            alt=""
-          />
-        ))}
-        {showBadge && overflow > 0 && <EventOverflowBadge>+{overflow}</EventOverflowBadge>}
-      </EventAvatarStack>
+      <FightCloudWrapper>
+        <FightCloudSvg width={cloudW} height={cloudH} viewBox={`0 0 ${cloudW} ${cloudH}`} aria-hidden="true">
+          <g opacity="0.55">
+            <ellipse cx={cloudW * 0.5} cy={cloudH * 0.52} rx={cloudW * 0.48} ry={cloudH * 0.44} fill="var(--fightCloudFill, rgba(180,190,210,0.32))" />
+            <ellipse cx={cloudW * 0.22} cy={cloudH * 0.42} rx={cloudW * 0.2} ry={cloudH * 0.36} fill="var(--fightCloudFill, rgba(180,190,210,0.32))" />
+            <ellipse cx={cloudW * 0.78} cy={cloudH * 0.42} rx={cloudW * 0.2} ry={cloudH * 0.36} fill="var(--fightCloudFill, rgba(180,190,210,0.32))" />
+            <ellipse cx={cloudW * 0.35} cy={cloudH * 0.28} rx={cloudW * 0.17} ry={cloudH * 0.24} fill="var(--fightCloudFill, rgba(180,190,210,0.32))" />
+            <ellipse cx={cloudW * 0.65} cy={cloudH * 0.28} rx={cloudW * 0.17} ry={cloudH * 0.24} fill="var(--fightCloudFill, rgba(180,190,210,0.32))" />
+            <ellipse cx={cloudW * 0.5} cy={cloudH * 0.72} rx={cloudW * 0.32} ry={cloudH * 0.22} fill="var(--fightCloudFill, rgba(180,190,210,0.32))" />
+          </g>
+          <g fill="var(--fightCloudSparkle, rgba(160,170,190,0.45))">
+            <polygon points={`${cloudW * 0.08},${cloudH * 0.18} ${cloudW * 0.1},${cloudH * 0.12} ${cloudW * 0.12},${cloudH * 0.18} ${cloudW * 0.1},${cloudH * 0.24}`} />
+            <polygon points={`${cloudW * 0.9},${cloudH * 0.2} ${cloudW * 0.92},${cloudH * 0.14} ${cloudW * 0.94},${cloudH * 0.2} ${cloudW * 0.92},${cloudH * 0.26}`} />
+            <polygon points={`${cloudW * 0.15},${cloudH * 0.75} ${cloudW * 0.17},${cloudH * 0.7} ${cloudW * 0.19},${cloudH * 0.75} ${cloudW * 0.17},${cloudH * 0.8}`} />
+            <polygon points={`${cloudW * 0.84},${cloudH * 0.72} ${cloudW * 0.86},${cloudH * 0.67} ${cloudW * 0.88},${cloudH * 0.72} ${cloudW * 0.86},${cloudH * 0.77}`} />
+          </g>
+        </FightCloudSvg>
+        <EventAvatarStack>
+          {preview.map((participant, index) => (
+            <EventAvatarImage
+              key={`${participant.profileId ?? participant.displayName ?? "participant"}_${index}`}
+              src={emojis.getEmojiUrl(participant.emojiId!.toString())}
+              alt=""
+            />
+          ))}
+          {showBadge && overflow > 0 && <EventOverflowBadge>+{overflow}</EventOverflowBadge>}
+        </EventAvatarStack>
+      </FightCloudWrapper>
     );
   };
 


### PR DESCRIPTION
## Summary
This PR adds a decorative cloud SVG background behind event participant avatars in the navigation picker, enhancing the visual presentation of fight/event information.

## Key Changes
- **New styled components**: Added `FightCloudWrapper` and `FightCloudSvg` to wrap and position the cloud SVG
- **Cloud SVG rendering**: Implemented a dynamic cloud shape using multiple ellipses and sparkle accents that scales based on the number of visible participants
- **Updated EventAvatarStack**: Added positioning context (`position: relative`), padding, and z-index to layer avatars above the cloud background
- **Removed EventOverflowBadge background**: Changed from semi-transparent gray background to `background: none` and removed dark mode specific styling, allowing the cloud to show through
- **CSS variables**: Added `--fightCloudFill` and `--fightCloudSparkle` variables with light and dark mode variants for theme consistency

## Implementation Details
- The cloud dimensions are calculated dynamically based on item count: `Math.max(36, itemCount * 21 + 14)` for width and fixed 30px height
- The SVG uses relative positioning (percentages of cloudW/cloudH) to scale responsively
- Cloud opacity is set to 0.55 with sparkle elements at 0.45 opacity for a subtle, non-intrusive effect
- The cloud SVG is positioned absolutely and centered behind the avatar stack using `transform: translate(-50%, -50%)`
- Pointer events are disabled on the SVG to prevent interaction interference

https://claude.ai/code/session_01WpDU8vQWD9XGo8XeZUyAw5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only UI change limited to `NavigationPicker` styling and a couple of new theme CSS variables. Main risk is minor layout/overlap regressions in the event avatar row across light/dark themes.
> 
> **Overview**
> Adds a decorative, dynamically-sized SVG “fight cloud” background behind event participant avatars in `NavigationPicker`, with avatars layered above via new wrapper/positioning styles.
> 
> Introduces new theme variables `--fightCloudFill` and `--fightCloudSparkle` (light/dark variants) and removes the overflow badge’s tinted background so the cloud shows through.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01ae1bc658c23e54b36c9fade9e78f626aa80585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a decorative cloud SVG behind event avatars in the navigation picker to boost visual polish. No row height or interactions changed.

- **New Features**
  - Wraps avatar stack in `FightCloudWrapper` with a single inline `FightCloudSvg`.
  - Cloud width scales with visible items; 30px height; centered behind avatars; pointer-events disabled.
  - Adds `--fightCloudFill` and `--fightCloudSparkle` CSS variables with light/dark values.
  - Sets `EventAvatarStack` to `position: relative` with small padding and z-index to layer above the cloud.
  - Removes `EventOverflowBadge` background so the cloud shows through.

<sup>Written for commit 01ae1bc658c23e54b36c9fade9e78f626aa80585. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

