### PR TITLE
Add decorative cloud backdrop to event participant avatars

### DIFF
--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -154,6 +154,7 @@ const EventAvatarStack = styled.div`
   align-items: center;
   gap: 1px;
   flex-shrink: 0;
+  position: relative;
 `;
 
 const EventAvatarImage = styled(GameEmojiImage)``;
@@ -178,6 +179,20 @@ const EventOverflowBadge = styled.span`
 
   @media (prefers-color-scheme: dark) {
     background: rgba(255, 255, 255, 0.07);
+  }
+`;
+
+const FightCloudContainer = styled.div`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: 1px;
+  --cloud-puff: rgba(0, 0, 0, 0.05);
+  --cloud-star: rgba(0, 0, 0, 0.15);
+
+  @media (prefers-color-scheme: dark) {
+    --cloud-puff: rgba(255, 255, 255, 0.065);
+    --cloud-star: rgba(255, 255, 255, 0.19);
   }
 `;
 
@@ -318,6 +333,48 @@ const HomeBoardButton = styled.button<{ $withTopBorder?: boolean }>`
     }
   }
 `;
+
+const fightCloudStarPoints = (cx: number, cy: number, r: number): string => {
+  const ir = r * 0.3;
+  return `${cx},${cy - r} ${cx + ir},${cy - ir} ${cx + r},${cy} ${cx + ir},${cy + ir} ${cx},${cy + r} ${cx - ir},${cy + ir} ${cx - r},${cy} ${cx - ir},${cy - ir}`;
+};
+
+const FightCloudBackdrop: React.FC<{ avatarCount: number; hasBadge: boolean }> = React.memo(({ avatarCount, hasBadge }) => {
+  const contentW = Math.max(1, avatarCount) * 21 - 1 + (hasBadge ? 20 : 0);
+  const px = 5;
+  const py = 4;
+  const w = contentW + px * 2;
+  const h = 20 + py * 2;
+  const cx = w / 2;
+  const cy = h / 2;
+
+  return (
+    <svg
+      aria-hidden="true"
+      overflow="visible"
+      width={w}
+      height={h}
+      viewBox={`0 0 ${w} ${h}`}
+      style={{
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        pointerEvents: "none",
+      }}
+    >
+      <ellipse cx={cx} cy={cy} rx={cx - 1} ry={cy - 0.5} fill="var(--cloud-puff)" />
+      <circle cx={px + 2} cy={cy - 1} r={cy * 0.7} fill="var(--cloud-puff)" />
+      <circle cx={w - px - 2} cy={cy + 1} r={cy * 0.65} fill="var(--cloud-puff)" />
+      <circle cx={cx * 0.7} cy={py * 0.3} r={cy * 0.5} fill="var(--cloud-puff)" />
+      <circle cx={cx * 1.3} cy={h - py * 0.3} r={cy * 0.45} fill="var(--cloud-puff)" />
+      <circle cx={cx * 1.1} cy={py * 0.5} r={cy * 0.4} fill="var(--cloud-puff)" />
+      <polygon points={fightCloudStarPoints(w - 1, 3.5, 2.5)} fill="var(--cloud-star)" />
+      <polygon points={fightCloudStarPoints(2, h - 2.5, 2)} fill="var(--cloud-star)" />
+      <polygon points={fightCloudStarPoints(cx * 1.4, 1.5, 1.8)} fill="var(--cloud-star)" />
+    </svg>
+  );
+});
 
 const MIN_AUTO_LOAD_NEXT_PAGE_THRESHOLD_PX = 640;
 const MIN_REASONABLE_EPOCH_MS = Date.UTC(2000, 0, 1);
@@ -551,17 +608,21 @@ const NavigationPicker: React.FC<NavigationPickerProps> = ({
     const maxVisible = showBadge ? 5 : 6;
     const preview = validParticipants.slice(0, maxVisible);
     const overflow = event.participantCount - preview.length;
+    const hasBadge = showBadge && overflow > 0;
     return (
-      <EventAvatarStack>
-        {preview.map((participant, index) => (
-          <EventAvatarImage
-            key={`${participant.profileId ?? participant.displayName ?? "participant"}_${index}`}
-            src={emojis.getEmojiUrl(participant.emojiId!.toString())}
-            alt=""
-          />
-        ))}
-        {showBadge && overflow > 0 && <EventOverflowBadge>+{overflow}</EventOverflowBadge>}
-      </EventAvatarStack>
+      <FightCloudContainer>
+        {preview.length > 0 && <FightCloudBackdrop avatarCount={preview.length} hasBadge={hasBadge} />}
+        <EventAvatarStack>
+          {preview.map((participant, index) => (
+            <EventAvatarImage
+              key={`${participant.profileId ?? participant.displayName ?? "participant"}_${index}`}
+              src={emojis.getEmojiUrl(participant.emojiId!.toString())}
+              alt=""
+            />
+          ))}
+          {hasBadge && <EventOverflowBadge>+{overflow}</EventOverflowBadge>}
+        </EventAvatarStack>
+      </FightCloudContainer>
     );
   };
 


### PR DESCRIPTION
## Summary
Added a decorative cloud-themed SVG backdrop behind event participant avatars in the navigation picker, enhancing the visual presentation of event information.

## Key Changes
- **New styled component `FightCloudContainer`**: Wrapper for the avatar stack with relative positioning and CSS variables for cloud styling that adapts to light/dark color schemes
- **New component `FightCloudBackdrop`**: React memo component that renders an SVG cloud shape with decorative star accents, sized dynamically based on the number of avatars and presence of an overflow badge
- **Helper function `fightCloudStarPoints`**: Utility to generate SVG polygon points for 8-pointed stars used as cloud decorations
- **Updated `EventAvatarStack`**: Added `position: relative` to enable absolute positioning of the backdrop
- **Refactored avatar rendering logic**: Wrapped the avatar stack in the new `FightCloudContainer` and updated badge visibility logic to use a `hasBadge` variable for consistency

## Implementation Details
- The cloud backdrop is an SVG composed of overlapping ellipses and circles to create a fluffy cloud effect, with two decorative stars
- Cloud colors use CSS custom properties (`--cloud-puff` and `--cloud-star`) that automatically adjust for dark mode via `prefers-color-scheme` media query
- The backdrop is positioned absolutely and centered behind the avatars using `transform: translate(-50%, -50%)`
- The SVG dimensions are calculated based on avatar count (21px per avatar minus 1px gap) and badge width (20px if present)
- `pointer-events: none` ensures the backdrop doesn't interfere with interactions

https://claude.ai/code/session_012oMLxRep546mHSRWW4iWri

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, UI-only styling/rendering change confined to `NavigationPicker` with no data flow or behavioral changes beyond avatar preview presentation.
> 
> **Overview**
> Adds a decorative, theme-aware “fight cloud” SVG backdrop behind event participant avatar previews in `NavigationPicker`.
> 
> This introduces `FightCloudContainer` plus a memoized `FightCloudBackdrop` (with `fightCloudStarPoints`) sized based on avatar count and overflow badge presence, and slightly refactors the event preview render path to compute `hasBadge` and layer the backdrop behind the existing avatar stack.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50f7b587af9080e92e1bd8bc83522804eb47b967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a subtle cloud-themed SVG backdrop behind event participant avatars in the navigation picker to improve visual polish. The cloud scales with avatar count and supports dark mode without affecting interactions.

- New Features
  - Added `FightCloudContainer` wrapper and memoized `FightCloudBackdrop` SVG (with helper for star points).
  - Backdrop size adapts to avatar count and the overflow badge; positioned absolutely with `pointer-events: none`.
  - Uses CSS variables (`--cloud-puff`, `--cloud-star`) that auto-adjust for dark mode.
  - Updated `EventAvatarStack` to `position: relative` and unified overflow badge logic via `hasBadge`.

<sup>Written for commit 50f7b587af9080e92e1bd8bc83522804eb47b967. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

