### PR TITLE
Event rows fight cloud

### DIFF
--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -447,9 +447,9 @@ const QUEUE_MANA_SLOTS: QueueManaSlot[] = ["top", "right", "bottom", "left"];
 function buildFightCloudPath(w: number, h: number): string {
   const cx = w / 2;
   const cy = h / 2;
-  const rx = w / 2 - 3;
-  const ry = h / 2 - 2;
-  const n = Math.max(5, Math.min(8, Math.round(w / 14)));
+  const rx = w / 2 - 1;
+  const ry = h / 2 - 1;
+  const n = Math.max(7, Math.min(10, Math.round(w / 10)));
   const step = (Math.PI * 2) / n;
   const parts: string[] = [];
   for (let i = 0; i < n; i++) {
@@ -516,8 +516,8 @@ function getFightCloudPaths(w: number, h: number) {
   return v;
 }
 
-const FIGHT_CLOUD_PAD_X = 7;
-const FIGHT_CLOUD_H = 28;
+const FIGHT_CLOUD_PAD_X = 10;
+const FIGHT_CLOUD_H = 32;
 
 const NavigationPicker: React.FC<NavigationPickerProps> = ({
   showsHomeNavigation,

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -209,16 +209,57 @@ const GameText = styled.span`
   text-overflow: ellipsis;
 `;
 
-const EventAvatarStack = styled.div`
+const FightCloudWrap = styled.div`
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 1px;
+  justify-content: center;
   flex-shrink: 0;
+  margin-left: 2px;
 `;
 
 const EventAvatarImage = styled(GameEmojiImage)``;
 
-const EventOverflowBadge = styled.span`
+const FightCloudCanvas = styled.svg`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  overflow: visible;
+  pointer-events: none;
+`;
+
+const CloudShape = styled.path`
+  fill: currentColor;
+  fill-opacity: 0.05;
+  stroke: currentColor;
+  stroke-opacity: 0.09;
+  stroke-width: 0.6;
+
+  @media (prefers-color-scheme: dark) {
+    fill-opacity: 0.07;
+    stroke-opacity: 0.12;
+  }
+`;
+
+const SparkleShape = styled.path`
+  fill: currentColor;
+  fill-opacity: 0.14;
+
+  @media (prefers-color-scheme: dark) {
+    fill-opacity: 0.18;
+  }
+`;
+
+const FightCloudInner = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  z-index: 1;
+`;
+
+const FightCloudBadge = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -227,17 +268,16 @@ const EventOverflowBadge = styled.span`
   height: 18px;
   padding: 0 3px;
   border-radius: 9px;
-  margin-left: 0;
-  background: rgba(128, 128, 128, 0.09);
   font-size: 0.55rem;
   font-weight: 600;
   color: var(--navigationTextMuted);
   flex-shrink: 0;
   letter-spacing: -0.02em;
   white-space: nowrap;
+  background: rgba(128, 128, 128, 0.08);
 
   @media (prefers-color-scheme: dark) {
-    background: rgba(255, 255, 255, 0.07);
+    background: rgba(255, 255, 255, 0.06);
   }
 `;
 
@@ -403,6 +443,81 @@ const MIN_AUTO_LOAD_NEXT_PAGE_THRESHOLD_PX = 640;
 const MIN_REASONABLE_EPOCH_MS = Date.UTC(2000, 0, 1);
 const SELECTED_ITEM_VISIBILITY_MARGIN_PX = 8;
 const QUEUE_MANA_SLOTS: QueueManaSlot[] = ["top", "right", "bottom", "left"];
+
+function buildFightCloudPath(w: number, h: number): string {
+  const cx = w / 2;
+  const cy = h / 2;
+  const rx = w / 2 - 2;
+  const ry = h / 2 - 2;
+  const n = Math.max(12, Math.round((w + h) * 0.35));
+  const step = (Math.PI * 2) / n;
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = i * step;
+    const aM = a + step / 2;
+    const aE = a + step;
+    const x0 = cx + rx * Math.cos(a);
+    const y0 = cy + ry * Math.sin(a);
+    const bump = 2.8 + 1.6 * Math.sin(i * 3.7 + 1.2);
+    const cpx = cx + (rx + bump) * Math.cos(aM);
+    const cpy = cy + (ry + bump) * Math.sin(aM);
+    const x1 = cx + rx * Math.cos(aE);
+    const y1 = cy + ry * Math.sin(aE);
+    if (i === 0) parts.push(`M${x0.toFixed(1)},${y0.toFixed(1)}`);
+    parts.push(
+      `Q${cpx.toFixed(1)},${cpy.toFixed(1)},${x1.toFixed(1)},${y1.toFixed(1)}`,
+    );
+  }
+  parts.push("Z");
+  return parts.join("");
+}
+
+function buildSparklePath(
+  cx: number,
+  cy: number,
+  s: number,
+): string {
+  const d = s * 0.28;
+  return [
+    `M${cx},${(cy - s).toFixed(1)}`,
+    `L${(cx + d).toFixed(1)},${(cy - d).toFixed(1)}`,
+    `L${(cx + s).toFixed(1)},${cy}`,
+    `L${(cx + d).toFixed(1)},${(cy + d).toFixed(1)}`,
+    `L${cx},${(cy + s).toFixed(1)}`,
+    `L${(cx - d).toFixed(1)},${(cy + d).toFixed(1)}`,
+    `L${(cx - s).toFixed(1)},${cy}`,
+    `L${(cx - d).toFixed(1)},${(cy - d).toFixed(1)}`,
+    "Z",
+  ].join("");
+}
+
+function buildCloudSparkles(w: number, h: number): string {
+  const parts = [
+    buildSparklePath(w - 2, 3.5, 2.5),
+    buildSparklePath(3, h - 3, 2),
+  ];
+  if (w > 60) {
+    parts.push(buildSparklePath(w * 0.3, 1.5, 1.8));
+  }
+  if (w > 90) {
+    parts.push(buildSparklePath(w * 0.7, h - 1.5, 1.6));
+  }
+  return parts.join("");
+}
+
+const fightCloudCache = new Map<string, { cloud: string; sparkles: string }>();
+function getFightCloudPaths(w: number, h: number) {
+  const k = `${w}|${h}`;
+  let v = fightCloudCache.get(k);
+  if (!v) {
+    v = { cloud: buildFightCloudPath(w, h), sparkles: buildCloudSparkles(w, h) };
+    fightCloudCache.set(k, v);
+  }
+  return v;
+}
+
+const FIGHT_CLOUD_PAD_X = 7;
+const FIGHT_CLOUD_H = 28;
 
 const NavigationPicker: React.FC<NavigationPickerProps> = ({
   showsHomeNavigation,
@@ -675,19 +790,37 @@ const NavigationPicker: React.FC<NavigationPickerProps> = ({
     const maxVisible = showBadge ? 5 : 6;
     const preview = validParticipants.slice(0, maxVisible);
     const overflow = event.participantCount - preview.length;
+    const hasBadge = showBadge && overflow > 0;
+    const itemCount = preview.length + (hasBadge ? 1 : 0);
+
+    if (itemCount === 0) return null;
+
+    const contentW = itemCount * 21 - 1;
+    const cloudW = contentW + FIGHT_CLOUD_PAD_X * 2;
+    const { cloud, sparkles } = getFightCloudPaths(cloudW, FIGHT_CLOUD_H);
+
     return (
-      <EventAvatarStack>
-        {preview.map((participant, index) => (
-          <EventAvatarImage
-            key={`${participant.profileId ?? participant.displayName ?? "participant"}_${index}`}
-            src={emojis.getEmojiUrl(participant.emojiId!.toString())}
-            alt=""
-          />
-        ))}
-        {showBadge && overflow > 0 && (
-          <EventOverflowBadge>+{overflow}</EventOverflowBadge>
-        )}
-      </EventAvatarStack>
+      <FightCloudWrap>
+        <FightCloudCanvas
+          width={cloudW}
+          height={FIGHT_CLOUD_H}
+          viewBox={`0 0 ${cloudW} ${FIGHT_CLOUD_H}`}
+          aria-hidden="true"
+        >
+          <CloudShape d={cloud} />
+          <SparkleShape d={sparkles} />
+        </FightCloudCanvas>
+        <FightCloudInner>
+          {preview.map((participant, index) => (
+            <EventAvatarImage
+              key={`${participant.profileId ?? participant.displayName ?? "p"}_${index}`}
+              src={emojis.getEmojiUrl(participant.emojiId!.toString())}
+              alt=""
+            />
+          ))}
+          {hasBadge && <FightCloudBadge>+{overflow}</FightCloudBadge>}
+        </FightCloudInner>
+      </FightCloudWrap>
     );
   };
 

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -267,7 +267,7 @@ const CloudShape = styled.path`
   stroke: currentColor;
   stroke-opacity: 0.09;
   stroke-width: 0.6;
-  transition: fill-opacity 0.12s, stroke-opacity 0.12s, fill 0.12s, stroke 0.12s;
+  transition: fill-opacity 0.12s, stroke-opacity 0.12s;
 
   @media (hover: hover) and (pointer: fine) {
     button:hover & {
@@ -279,25 +279,6 @@ const CloudShape = styled.path`
   button:active & {
     fill-opacity: 0.14;
     stroke-opacity: 0.19;
-  }
-
-  button[data-navigation-active="true"] & {
-    fill: rgba(117, 187, 255, 1);
-    fill-opacity: 0.22;
-    stroke: rgba(117, 187, 255, 1);
-    stroke-opacity: 0.30;
-  }
-
-  @media (hover: hover) and (pointer: fine) {
-    button[data-navigation-active="true"]:hover & {
-      fill-opacity: 0.28;
-      stroke-opacity: 0.36;
-    }
-  }
-
-  button[data-navigation-active="true"]:active & {
-    fill-opacity: 0.34;
-    stroke-opacity: 0.42;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -315,32 +296,13 @@ const CloudShape = styled.path`
       fill-opacity: 0.16;
       stroke-opacity: 0.21;
     }
-
-    button[data-navigation-active="true"] & {
-      fill: rgba(75, 150, 255, 1);
-      fill-opacity: 0.24;
-      stroke: rgba(75, 150, 255, 1);
-      stroke-opacity: 0.32;
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-      button[data-navigation-active="true"]:hover & {
-        fill-opacity: 0.30;
-        stroke-opacity: 0.38;
-      }
-    }
-
-    button[data-navigation-active="true"]:active & {
-      fill-opacity: 0.36;
-      stroke-opacity: 0.44;
-    }
   }
 `;
 
 const SparkleShape = styled.path`
   fill: currentColor;
   fill-opacity: 0.14;
-  transition: fill-opacity 0.12s, fill 0.12s;
+  transition: fill-opacity 0.12s;
 
   @media (hover: hover) and (pointer: fine) {
     button:hover & {
@@ -350,21 +312,6 @@ const SparkleShape = styled.path`
 
   button:active & {
     fill-opacity: 0.24;
-  }
-
-  button[data-navigation-active="true"] & {
-    fill: rgba(117, 187, 255, 1);
-    fill-opacity: 0.40;
-  }
-
-  @media (hover: hover) and (pointer: fine) {
-    button[data-navigation-active="true"]:hover & {
-      fill-opacity: 0.48;
-    }
-  }
-
-  button[data-navigation-active="true"]:active & {
-    fill-opacity: 0.55;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -378,21 +325,6 @@ const SparkleShape = styled.path`
 
     button:active & {
       fill-opacity: 0.28;
-    }
-
-    button[data-navigation-active="true"] & {
-      fill: rgba(75, 150, 255, 1);
-      fill-opacity: 0.42;
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-      button[data-navigation-active="true"]:hover & {
-        fill-opacity: 0.50;
-      }
-    }
-
-    button[data-navigation-active="true"]:active & {
-      fill-opacity: 0.58;
     }
   }
 `;

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -448,7 +448,7 @@ function buildFightCloudPath(w: number, h: number): string {
   const cx = w / 2;
   const cy = h / 2;
   const rx = w / 2 - 1;
-  const ry = h / 2 - 4;
+  const ry = h / 2 - 2;
   const halfH = h / 2;
   const n = Math.max(7, Math.min(10, Math.round(w / 10)));
   const step = (Math.PI * 2) / n;
@@ -461,7 +461,7 @@ function buildFightCloudPath(w: number, h: number): string {
     const y0 = cy + ry * Math.sin(a);
     const baseBump = 4.5 + 2.5 * Math.sin(i * 3.7 + 1.2);
     const sinAbs = Math.abs(Math.sin(aM));
-    const vertMax = sinAbs > 0.01 ? halfH / sinAbs - ry : baseBump;
+    const vertMax = sinAbs > 0.01 ? (halfH + 3) / sinAbs - ry : baseBump;
     const bump = Math.min(baseBump, Math.max(0, vertMax));
     const cpx = cx + (rx + bump) * Math.cos(aM);
     const cpy = cy + (ry + bump) * Math.sin(aM);

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -447,9 +447,9 @@ const QUEUE_MANA_SLOTS: QueueManaSlot[] = ["top", "right", "bottom", "left"];
 function buildFightCloudPath(w: number, h: number): string {
   const cx = w / 2;
   const cy = h / 2;
-  const rx = w / 2 - 2;
+  const rx = w / 2 - 3;
   const ry = h / 2 - 2;
-  const n = Math.max(12, Math.round((w + h) * 0.35));
+  const n = Math.max(5, Math.min(8, Math.round(w / 14)));
   const step = (Math.PI * 2) / n;
   const parts: string[] = [];
   for (let i = 0; i < n; i++) {
@@ -458,7 +458,7 @@ function buildFightCloudPath(w: number, h: number): string {
     const aE = a + step;
     const x0 = cx + rx * Math.cos(a);
     const y0 = cy + ry * Math.sin(a);
-    const bump = 2.8 + 1.6 * Math.sin(i * 3.7 + 1.2);
+    const bump = 4.5 + 2.5 * Math.sin(i * 3.7 + 1.2);
     const cpx = cx + (rx + bump) * Math.cos(aM);
     const cpy = cy + (ry + bump) * Math.sin(aM);
     const x1 = cx + rx * Math.cos(aE);

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -448,7 +448,8 @@ function buildFightCloudPath(w: number, h: number): string {
   const cx = w / 2;
   const cy = h / 2;
   const rx = w / 2 - 1;
-  const ry = h / 2 - 3;
+  const ry = h / 2 - 4;
+  const halfH = h / 2;
   const n = Math.max(7, Math.min(10, Math.round(w / 10)));
   const step = (Math.PI * 2) / n;
   const parts: string[] = [];
@@ -458,8 +459,10 @@ function buildFightCloudPath(w: number, h: number): string {
     const aE = a + step;
     const x0 = cx + rx * Math.cos(a);
     const y0 = cy + ry * Math.sin(a);
-    const vert = Math.sin(aM) * Math.sin(aM);
-    const bump = (4.5 + 2.5 * Math.sin(i * 3.7 + 1.2)) * (1 - 0.65 * vert);
+    const baseBump = 4.5 + 2.5 * Math.sin(i * 3.7 + 1.2);
+    const sinAbs = Math.abs(Math.sin(aM));
+    const vertMax = sinAbs > 0.01 ? halfH / sinAbs - ry : baseBump;
+    const bump = Math.min(baseBump, Math.max(0, vertMax));
     const cpx = cx + (rx + bump) * Math.cos(aM);
     const cpy = cy + (ry + bump) * Math.sin(aM);
     const x1 = cx + rx * Math.cos(aE);

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -539,7 +539,7 @@ function buildFightCloudPath(w: number, h: number): string {
     const y0 = cy + ry * Math.sin(a);
     const baseBump = 4.5 + 2.5 * Math.sin(i * 3.7 + 1.2);
     const sinAbs = Math.abs(Math.sin(aM));
-    const vertMax = sinAbs > 0.01 ? (halfH + 3) / sinAbs - ry : baseBump;
+    const vertMax = sinAbs > 0.01 ? (halfH + 2) / sinAbs - ry : baseBump;
     const bump = Math.min(baseBump, Math.max(0, vertMax));
     const cpx = cx + (rx + bump) * Math.cos(aM);
     const cpy = cy + (ry + bump) * Math.sin(aM);

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -539,7 +539,7 @@ function buildFightCloudPath(w: number, h: number): string {
     const y0 = cy + ry * Math.sin(a);
     const baseBump = 4.5 + 2.5 * Math.sin(i * 3.7 + 1.2);
     const sinAbs = Math.abs(Math.sin(aM));
-    const vertMax = sinAbs > 0.01 ? (halfH + 2) / sinAbs - ry : baseBump;
+    const vertMax = sinAbs > 0.01 ? (halfH + 1) / sinAbs - ry : baseBump;
     const bump = Math.min(baseBump, Math.max(0, vertMax));
     const cpx = cx + (rx + bump) * Math.cos(aM);
     const cpy = cy + (ry + bump) * Math.sin(aM);

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -146,6 +146,38 @@ const GameRow = styled(NavigationPickerButton)<{
   padding-right: ${(props) => (props.$hasTrailingAction ? "32px" : "12px")};
 `;
 
+const EventRow = styled(GameRow)`
+  && {
+    background: transparent;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &&:hover {
+      background-color: transparent;
+    }
+  }
+
+  &&:active {
+    background-color: transparent;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    && {
+      background: transparent;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &&:hover {
+        background-color: transparent;
+      }
+    }
+
+    &&:active {
+      background-color: transparent;
+    }
+  }
+`;
+
 const GameRowContainer = styled.div`
   position: relative;
   width: 100%;
@@ -235,19 +267,133 @@ const CloudShape = styled.path`
   stroke: currentColor;
   stroke-opacity: 0.09;
   stroke-width: 0.6;
+  transition: fill-opacity 0.12s, stroke-opacity 0.12s, fill 0.12s, stroke 0.12s;
+
+  @media (hover: hover) and (pointer: fine) {
+    button:hover & {
+      fill-opacity: 0.10;
+      stroke-opacity: 0.15;
+    }
+  }
+
+  button:active & {
+    fill-opacity: 0.14;
+    stroke-opacity: 0.19;
+  }
+
+  button[data-navigation-active="true"] & {
+    fill: rgba(117, 187, 255, 1);
+    fill-opacity: 0.22;
+    stroke: rgba(117, 187, 255, 1);
+    stroke-opacity: 0.30;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    button[data-navigation-active="true"]:hover & {
+      fill-opacity: 0.28;
+      stroke-opacity: 0.36;
+    }
+  }
+
+  button[data-navigation-active="true"]:active & {
+    fill-opacity: 0.34;
+    stroke-opacity: 0.42;
+  }
 
   @media (prefers-color-scheme: dark) {
     fill-opacity: 0.07;
     stroke-opacity: 0.12;
+
+    @media (hover: hover) and (pointer: fine) {
+      button:hover & {
+        fill-opacity: 0.12;
+        stroke-opacity: 0.17;
+      }
+    }
+
+    button:active & {
+      fill-opacity: 0.16;
+      stroke-opacity: 0.21;
+    }
+
+    button[data-navigation-active="true"] & {
+      fill: rgba(75, 150, 255, 1);
+      fill-opacity: 0.24;
+      stroke: rgba(75, 150, 255, 1);
+      stroke-opacity: 0.32;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      button[data-navigation-active="true"]:hover & {
+        fill-opacity: 0.30;
+        stroke-opacity: 0.38;
+      }
+    }
+
+    button[data-navigation-active="true"]:active & {
+      fill-opacity: 0.36;
+      stroke-opacity: 0.44;
+    }
   }
 `;
 
 const SparkleShape = styled.path`
   fill: currentColor;
   fill-opacity: 0.14;
+  transition: fill-opacity 0.12s, fill 0.12s;
+
+  @media (hover: hover) and (pointer: fine) {
+    button:hover & {
+      fill-opacity: 0.20;
+    }
+  }
+
+  button:active & {
+    fill-opacity: 0.24;
+  }
+
+  button[data-navigation-active="true"] & {
+    fill: rgba(117, 187, 255, 1);
+    fill-opacity: 0.40;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    button[data-navigation-active="true"]:hover & {
+      fill-opacity: 0.48;
+    }
+  }
+
+  button[data-navigation-active="true"]:active & {
+    fill-opacity: 0.55;
+  }
 
   @media (prefers-color-scheme: dark) {
     fill-opacity: 0.18;
+
+    @media (hover: hover) and (pointer: fine) {
+      button:hover & {
+        fill-opacity: 0.24;
+      }
+    }
+
+    button:active & {
+      fill-opacity: 0.28;
+    }
+
+    button[data-navigation-active="true"] & {
+      fill: rgba(75, 150, 255, 1);
+      fill-opacity: 0.42;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      button[data-navigation-active="true"]:hover & {
+        fill-opacity: 0.50;
+      }
+    }
+
+    button[data-navigation-active="true"]:active & {
+      fill-opacity: 0.58;
+    }
   }
 `;
 
@@ -850,9 +996,10 @@ const NavigationPicker: React.FC<NavigationPickerProps> = ({
             onRemoveGame?.(game.inviteId);
           }
         };
+        const Row = event ? EventRow : GameRow;
         return (
           <GameRowContainer key={item.id}>
-            <GameRow
+            <Row
               $isSelected={isSelected}
               $hasTrailingAction={canRemove}
               data-navigation-active={isActiveItem ? "true" : undefined}
@@ -916,7 +1063,7 @@ const NavigationPicker: React.FC<NavigationPickerProps> = ({
                   )}
                 </>
               ) : null}
-            </GameRow>
+            </Row>
             {canRemove && (
               <GameRemoveButton
                 type="button"

--- a/src/ui/NavigationPicker.tsx
+++ b/src/ui/NavigationPicker.tsx
@@ -448,7 +448,7 @@ function buildFightCloudPath(w: number, h: number): string {
   const cx = w / 2;
   const cy = h / 2;
   const rx = w / 2 - 1;
-  const ry = h / 2 - 1;
+  const ry = h / 2 - 3;
   const n = Math.max(7, Math.min(10, Math.round(w / 10)));
   const step = (Math.PI * 2) / n;
   const parts: string[] = [];
@@ -458,7 +458,8 @@ function buildFightCloudPath(w: number, h: number): string {
     const aE = a + step;
     const x0 = cx + rx * Math.cos(a);
     const y0 = cy + ry * Math.sin(a);
-    const bump = 4.5 + 2.5 * Math.sin(i * 3.7 + 1.2);
+    const vert = Math.sin(aM) * Math.sin(aM);
+    const bump = (4.5 + 2.5 * Math.sin(i * 3.7 + 1.2)) * (1 - 0.65 * vert);
     const cpx = cx + (rx + bump) * Math.cos(aM);
     const cpy = cy + (ry + bump) * Math.sin(aM);
     const x1 = cx + rx * Math.cos(aE);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a "Fight Cloud" visual element to event rows in `NavigationPicker.tsx` to provide a distinguished look for player avatars.

This feature introduces a dynamically sized, adaptive light/dark SVG cloud with subtle sparkles, designed to efficiently encapsulate player avatars and badges within event rows without affecting performance. SVG path strings are cached to ensure smooth rendering, and the cloud's appearance adjusts to the number of avatars while maintaining the row's original height.

<div><a href="https://cursor.com/agents/bc-6be6c363-d4c8-4981-9fc0-37383d43250a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6be6c363-d4c8-4981-9fc0-37383d43250a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Fight Cloud” SVG behind event row avatars in `NavigationPicker.tsx` to group participants and the overflow badge for clearer scanning. Hover/active feedback lives on the cloud (not the row); no persistent selected highlight.

- **New Features**
  - 32px cloud with 10px side padding; vertical extent pulled in slightly to avoid clipping.
  - 7–10 puffs; top bumps up to ~5px; width auto-scales to avatar+badge count.
  - Subtle 4-point sparkles at edges.
  - Two paths (cloud + sparkles), cached by size; SVG is aria-hidden.
  - Overflow badge (+N) and avatars sit inside the cloud; avatars nudged 2px right.
  - Uses currentColor with tuned light/dark opacities; cloud/sparkles react on hover and active only; event rows are transparent; game rows unchanged.

<sup>Written for commit 61713cecd34987007141ae669b9706015aa7a7e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

